### PR TITLE
Decreases disconnect timeout in conference migration.

### DIFF
--- a/src/org/jitsi/meet/test/ConferenceMigrationTest.java
+++ b/src/org/jitsi/meet/test/ConferenceMigrationTest.java
@@ -116,7 +116,7 @@ public class ConferenceMigrationTest
                     ".replace(/\\&?config.enforcedBridge=\".+\"/,\"\");" +
                     "config.enforcedBridge=undefined;");
 
-        // Graceful shutdown migrated bridge
+        // Migrated bridge
         final String jvbEndpoint = jvbRESTEndpoint;
         new Thread(new Runnable()
         {
@@ -140,9 +140,9 @@ public class ConferenceMigrationTest
         }).start();
 
         System.err.println("Wait for disconnected...");
-        ConferenceFixture.waitForIceDisconnected(owner, 45);
+        ConferenceFixture.waitForIceDisconnected(owner, 15);
         System.err.println("Owner - ICE disconnected!");
-        ConferenceFixture.waitForIceDisconnected(secondParticipant, 45);
+        ConferenceFixture.waitForIceDisconnected(secondParticipant, 15);
         System.err.println("Second peer - ICE disconnected!");
 
         // Wait for conference restart


### PR DESCRIPTION
Jicofo with active health checks should detect failure faster.

To be merged only once https://github.com/jitsi/jicofo/pull/41 is merged and once we have page reload fixed in jitsi-meet.