### PR TITLE
BugFix - StartMutedTest:

### DIFF
--- a/src/org/jitsi/meet/test/StartMutedTest.java
+++ b/src/org/jitsi/meet/test/StartMutedTest.java
@@ -124,12 +124,12 @@ public class StartMutedTest
 
         // Unmute and see if the audio works
         MeetUIUtils.clickOnToolbarButton(
-            secondParticipant, "toolbar_button_mute");
+            owner, "toolbar_button_mute");
         ((JavascriptExecutor) owner)
             .executeScript(
                 "console.log('configOptionsTest, unmuted second participant');");
         MeetUIUtils.waitForAudioMuted(
-            owner, secondParticipant, "second peer", false /* unmuted */);
+            secondParticipant, owner, "owner", false /* unmuted */);
     }
 
     /**


### PR DESCRIPTION
- changed to owner for the click of 'toolbar_button_mute'
- made the secondParticipant the observer and the owner the testee to match the test setup.