### PR TITLE
Let the tests fail when the hangup button is not clickable

### DIFF
--- a/src/org/jitsi/meet/test/ConferenceFixture.java
+++ b/src/org/jitsi/meet/test/ConferenceFixture.java
@@ -655,31 +655,22 @@ public class ConferenceFixture
             return;
         }
 
-        try
+        MeetUIUtils.clickOnToolbarButton(
+            participant, "toolbar_button_hangup", false);
+
+        TestUtils.waitMillis(500);
+
+        if (participant == owner)
         {
-            MeetUIUtils.clickOnToolbarButton(
-                participant, "toolbar_button_hangup", false);
-
-            TestUtils.waitMillis(500);
-
-            if (participant == owner)
-            {
-                ownerHungUp = true;
-            }
-            else if (participant == secondParticipant)
-            {
-                secondParticipantHungUp = true;
-            }
-            else if (participant == thirdParticipant)
-            {
-                thirdParticipantHungUp = true;
-            }
+            ownerHungUp = true;
         }
-        catch(Throwable t)
+        else if (participant == secondParticipant)
         {
-            t.printStackTrace();
-
-            quit(participant, false);
+            secondParticipantHungUp = true;
+        }
+        else if (participant == thirdParticipant)
+        {
+            thirdParticipantHungUp = true;
         }
 
         String instanceName = getParticipantName(participant);


### PR DESCRIPTION
If we catch Throwable and then quit the driver there will be no screenshot
taken for the test which has failed. It was not the right thing to ignore
the hangup button being not clickable. If there is a specific case where
this could be ignored then it should be handled accordingly instead.