### PR TITLE
Test participant conn status

### DIFF
--- a/src/org/jitsi/meet/test/ConferenceFixture.java
+++ b/src/org/jitsi/meet/test/ConferenceFixture.java
@@ -796,7 +796,7 @@ public class ConferenceFixture
      */
     public static void waitForOwnerToJoinMUC()
     {
-        if (owner == null)
+        if (owner == null || ownerHungUp)
             startOwner(null);
 
         MeetUtils.waitForParticipantToJoinMUC(owner, 15);

--- a/src/org/jitsi/meet/test/EndConferenceTest.java
+++ b/src/org/jitsi/meet/test/EndConferenceTest.java
@@ -68,5 +68,13 @@ public class EndConferenceTest
                     return !url.equals(owner.getCurrentUrl());
                 }
             });
+
+        // Close the owner, as the welcome page is not a state recognized
+        // by the ConferenceFixture and it will fail to figure out that
+        // the owner must be restarted in case any tests are to follow
+        // the EndConferenceTest.
+        // It simpler to close it than implement extra state which would not
+        // be of much use.
+        ConferenceFixture.close(owner);
     }
 }


### PR DESCRIPTION
Fixes the tests when PeerConnectionStatus test is scheduled after the EndConference test