### PR TITLE
Increase waiting timeout in PeerConnectionStatusTest

### DIFF
--- a/src/org/jitsi/meet/test/util/MeetUIUtils.java
+++ b/src/org/jitsi/meet/test/util/MeetUIUtils.java
@@ -993,7 +993,7 @@ public class MeetUIUtils
         assertNotNull(peerId);
 
         // may take time for the video to recover(key frame) than disrupt
-        int timeout = isConnected ? 20 : 7;
+        int timeout = isConnected ? 60 : 15;
 
         // Wait for the logic to tell that the user is disconnected
         TestUtils.waitForBoolean(


### PR DESCRIPTION
It looks like 'googSuspendBelowMinBitrate' = true can significantly
increase the time it takes for the video to unfreeze during the test.