### PR TITLE
fix: Disable sendside video suspension for the LipSyncTest.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/LipSyncTest.java
+++ b/src/test/java/org/jitsi/meet/test/LipSyncTest.java
@@ -107,7 +107,8 @@ public class LipSyncTest
         WebDriver owner
             = ConferenceFixture.startOwner(
                     "config.enableLipSync=true&config.audioPacketDelay=15" +
-                        "&config.audioLevelsInterval=100");
+                        "&config.audioLevelsInterval=100" +
+                        "&config.disableSuspendVideo=true");
         WebDriver participant = ConferenceFixture.getSecondParticipant();
 
         // Wait for the conference to start


### PR DESCRIPTION
The `googEnableVideoSuspendBelowMinBitrate` flag is breaking our lipsync test because sending video is suspended and never reactivated. It could be due to several things: a problem in our padding termination (their padding is killed before it reaches our remote bitrate estimator), a problem in the old GCC implementation, or a problem in their padding budget calculation.