### PR TITLE
fix(build): remove scope declaration for testng dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>6.11</version>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
The compile step uses all java files in src/test/java. With the
testng dependency declared with a scope of test, it would not be
available during compile. By removing the scope, testng will
fall back to the default scope of compile.