### PR TITLE
DataChannelTest: rework isDataChannelOpen() test based on new BridgeChannel

### DIFF
--- a/src/test/java/org/jitsi/meet/test/DataChannelTest.java
+++ b/src/test/java/org/jitsi/meet/test/DataChannelTest.java
@@ -70,10 +70,7 @@ public class DataChannelTest
      */
     private Boolean isDataChannelOpen(WebDriver webDriver)
     {
-        String script
-            = "return APP.conference._room.rtc.dataChannels._some(function (dataChannel) {"
-                + "    return dataChannel.readyState == 'open';"
-                + "});";
+        String script = "return APP.conference._room.rtc._channel.isOpen()";
 
         return TestUtils.executeScriptAndReturnBoolean(webDriver, script);
     }

--- a/src/test/java/org/jitsi/meet/test/DataChannelTest.java
+++ b/src/test/java/org/jitsi/meet/test/DataChannelTest.java
@@ -89,7 +89,7 @@ public class DataChannelTest
      */
     private Boolean isServerHelloReceived(WebDriver webDriver)
     {
-        String script = "return APP.conference._room.rtc.dataChannels.receivedServerHello;";
+        String script = "return APP.conference._room.rtc._channel.receivedServerHello;";
 
         return TestUtils.executeScriptAndReturnBoolean(webDriver, script);
     }
@@ -110,19 +110,16 @@ public class DataChannelTest
             = "APP.conference._room.rtc.addListener("
                 + "        'rtc.datachannel.ServerHello',"
                 + "        function (o) {"
-                + "            APP.conference._room.rtc.dataChannels.receivedServerHello = true;"
+                + "            APP.conference._room.rtc._channel.receivedServerHello = true;"
                 + "        });"
-                + "return APP.conference._room.rtc.dataChannels._some(function (dataChannel) {"
-                + "    if (dataChannel.readyState == 'open') {"
-                + "        APP.conference._room.rtc.dataChannels.receivedServerHello = false;"
-                + "        dataChannel.send(JSON.stringify({"
-                + "            'colibriClass': 'ClientHello'"
-                + "        }));"
-                + "        return true;"
-                + "    } else {"
-                + "        return false;"
-                + "    }"
-                + "});";
+                + "if (!APP.conference._room.rtc._channel.isOpen()) {"
+                + "    return false;"
+                + "}"
+                + "APP.conference._room.rtc._channel.receivedServerHello = false;"
+                + "APP.conference._room.rtc._channel._channel.send(JSON.stringify({"
+                + "    'colibriClass': 'ClientHello'"
+                + "}));"
+                + "return true;";
 
         return TestUtils.executeScriptAndReturnBoolean(webDriver, script);
     }


### PR DESCRIPTION
Related to issue [509](https://github.com/jitsi/lib-jitsi-meet/pull/509) "Make it possible to use WebSocket instead of DataChannel" in lib-jitsi-meet. Requested in this [comment](https://github.com/jitsi/lib-jitsi-meet/pull/509#issuecomment-309024836).

/CC @damencho