### PR TITLE
fix(1-on-1): adjust toolbar hide times, change hover selector

### DIFF
--- a/src/test/java/org/jitsi/meet/test/OneOnOneTest.java
+++ b/src/test/java/org/jitsi/meet/test/OneOnOneTest.java
@@ -41,8 +41,8 @@ public class OneOnOneTest
      */
     private final String oneOnOneConfigOverrides
         = "config.disable1On1Mode=false"
-        + "&interfaceConfig.TOOLBAR_TIMEOUT=500"
-        + "&interfaceConfig.INITIAL_TOOLBAR_TIMEOUT=500"
+        + "&interfaceConfig.TOOLBAR_TIMEOUT=250"
+        + "&interfaceConfig.INITIAL_TOOLBAR_TIMEOUT=250"
         + "&config.alwaysVisibleToolbar=false";
 
     /**
@@ -152,7 +152,7 @@ public class OneOnOneTest
     public void testFilmstripHoverShowsVideos() {
         WebDriver owner = ConferenceFixture.getOwner();
 
-        WebElement toolbar = owner.findElement(By.id("remoteVideos"));
+        WebElement toolbar = owner.findElement(By.id("localVideoContainer"));
         Actions hoverOnToolbar = new Actions(owner);
         hoverOnToolbar.moveToElement(toolbar);
         hoverOnToolbar.perform();


### PR DESCRIPTION
- The toolbar display durations have been reduced to compensate
  for a torture test machine that might be a little slow.
- The selector for the mousehover target, for showing remote
  videos, has been changed to one that is guaranteed to be
  available.