### PR TITLE
fix(follow-me): move mouse off toolbar after click

### DIFF
--- a/src/test/java/org/jitsi/meet/test/util/MeetUIUtils.java
+++ b/src/test/java/org/jitsi/meet/test/util/MeetUIUtils.java
@@ -240,6 +240,12 @@ public class MeetUIUtils
                 return;
 
             button.click();
+
+            // Move the mouse off the button to dismiss any tooltip that might
+            // have displayed.
+            Actions mouseOut = new Actions(participant);
+            mouseOut.moveToElement(participant.findElement(By.tagName("head")));
+            mouseOut.perform();
         }
         catch (NoSuchElementException e)
         {


### PR DESCRIPTION
With a recent tooltip update, tooltips no longer dismiss
from a toolbar button after the button is clicked. This
is intentional and a workaround is to move the mouse
off the button after click.