### PR TITLE
ref(lock-room): replace LockRoomTest with NewLockRoomTest

### DIFF
--- a/src/test/resources/desktop/testng.xml
+++ b/src/test/resources/desktop/testng.xml
@@ -92,11 +92,6 @@
             <class name="org.jitsi.meet.test.MuteTest" />
         </classes>
     </test>
-    <test name="NewLockRoomTest">
-        <classes>
-            <class name="org.jitsi.meet.test.NewLockRoomTest" />
-        </classes>
-    </test>
     <test name="OneOnOneTest">
         <classes>
             <class name="org.jitsi.meet.test.OneOnOneTest" />


### PR DESCRIPTION
Now that Invite Modal is being removed, remove LockRoomTest
which exercised the modal's lock feature. Rename NewLockRoomTest
which also exercises the lock feature but in the Info Dialog.