### PR TITLE
Records logs and screenshots when configuration fails.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/base/AbstractBaseTest.java
+++ b/src/test/java/org/jitsi/meet/test/base/AbstractBaseTest.java
@@ -134,6 +134,9 @@ public abstract class AbstractBaseTest
 
         participants = new ParticipantHelper(new ParticipantFactory(config));
 
+        // if this one fails, the failure will be registered in the
+        // FailureListener to gather information and it will call
+        // the cleanupClass() to clean up any leftovers
         setupClass();
     }
 

--- a/src/test/java/org/jitsi/meet/test/base/AbstractBaseTest.java
+++ b/src/test/java/org/jitsi/meet/test/base/AbstractBaseTest.java
@@ -134,17 +134,7 @@ public abstract class AbstractBaseTest
 
         participants = new ParticipantHelper(new ParticipantFactory(config));
 
-        // make sure if setup fails we will cleanup
-        // when configure method @BeforeClass fails @AfterClass is not executed
-        try
-        {
-            setupClass();
-        }
-        catch (Throwable t)
-        {
-            cleanupClass();
-            throw t;
-        }
+        setupClass();
     }
 
     /**

--- a/src/test/java/org/jitsi/meet/test/base/FailureListener.java
+++ b/src/test/java/org/jitsi/meet/test/base/FailureListener.java
@@ -186,8 +186,12 @@ public class FailureListener
     @Override
     public void onConfigurationFailure(ITestResult itr)
     {
+        // we want to catch failures to configure a test, so we can record
+        // logs, screenshots and any information as we do as normal test fails
+        // and we skip any other configuration failures as @AfterClass
         Object testInstance = itr.getInstance();
-        if (testInstance instanceof AbstractBaseTest)
+        if (testInstance instanceof AbstractBaseTest
+            && itr.getMethod().isBeforeClassConfiguration())
         {
             // record whatever we can
             onTestFailure(itr);


### PR DESCRIPTION
Moves the failed configuration tests to the set of failed tests to be easily recognised in html report.