### PR TITLE
fix(VideoOperator): fix class cast exception

### DIFF
--- a/src/test/java/org/jitsi/meet/test/PSNRTest.java
+++ b/src/test/java/org/jitsi/meet/test/PSNRTest.java
@@ -198,8 +198,7 @@ public class PSNRTest
         ownerVideoOperator.stopRecording();
 
         print("REAL FPS: " + ownerVideoOperator.getRealFPS());
-        print(
-                "RAW DATA SIZE: " + ownerVideoOperator.getRawDataSize() + "MB");
+        print("RAW DATA SIZE: " + ownerVideoOperator.getRawDataSize() + "MB");
 
         // now close second participant to maximize performance
         getParticipant2().hangUp();

--- a/src/test/java/org/jitsi/meet/test/capture/VideoOperator.java
+++ b/src/test/java/org/jitsi/meet/test/capture/VideoOperator.java
@@ -117,22 +117,22 @@ public class VideoOperator
 
     /**
      * Returns raw data size of all frames in MB.
-     * @return a <tt>Double</tt> value in MB.
+     * @return a <tt>Number</tt> or <tt>Long</tt> value in MB.
      */
-    public Double getRawDataSize()
+    public Number getRawDataSize()
     {
-        return (Double) getJSExecutor().executeScript(
+        return (Number) getJSExecutor().executeScript(
                 "return window._operator.getRawDataSize() / 1024 / 1024");
     }
 
     /**
      * Returns "real FPS" as defined in PSNRVideoOperator.js
-     * @return a <tt>Double</tt> with the FPS value calculated in
+     * @return a <tt>Number</tt> with the FPS value calculated in
      * PSNRVideoOperator.js
      */
-    public Double getRealFPS()
+    public Number getRealFPS()
     {
-        return (Double) getJSExecutor().executeScript(
+        return (Number) getJSExecutor().executeScript(
                 "return window._operator.getRealFPS()");
     }
 


### PR DESCRIPTION
The method sometimes fails with: "java.lang.ClassCastException:
java.lang.Long cannot be cast to java.lang.Double".

I guess that if the value happens to be integer it can be Long instead
of Double. Make it Number given that it's only used in a debug log.