### PR TITLE
fix(Participant): move file in takeScreenshot

### DIFF
--- a/src/test/java/org/jitsi/meet/test/base/Participant.java
+++ b/src/test/java/org/jitsi/meet/test/base/Participant.java
@@ -381,14 +381,17 @@ public abstract class Participant<T extends WebDriver>
         }
 
         TakesScreenshot takesScreenshot = (TakesScreenshot) driver;
-
         File scrFile = takesScreenshot.getScreenshotAs(OutputType.FILE);
-        if (!scrFile.renameTo(new File(outputDir, fileName)))
+        File dstFile = new File(outputDir, fileName);
+        try
+        {
+            FileUtils.moveFile(scrFile, dstFile);
+        }
+        catch (IOException ioe)
         {
             throw new RuntimeException(
-                "Failed to rename screenshot file to directory name: "
-                    + outputDir.toString() + ", file name: " + fileName
-                    + ", original file: " + scrFile.toString());
+                "Failed to move the screenshot file, from: "
+                    + scrFile.toString() + " to: " + dstFile.toString(), ioe);
         }
     }
 


### PR DESCRIPTION
Rename will not work for some cases. Unfortunately I can not explain
them exactly - maybe it was just wrong way of doing things. Previously
we used "copyFile" to do that. I want to give "moveFile" a try since it
will preserve some resources by not keeping two files.