### PR TITLE
fix: Attempts to fix an intermittent failure in the chat panel tests.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
@@ -294,6 +294,7 @@ public class WebParticipant extends Participant<WebDriver>
         WebDriver driver = getDriver();
         WebElement largeVideo = driver.findElement(By.id("largeVideo"));
         Actions actions = new Actions(driver);
+        actions.moveToElement(largeVideo);
         actions.sendKeys(largeVideo, shortcut.toString());
         actions.perform();
     }


### PR DESCRIPTION
The tests were observed to sometimes fail with the "c" shortcut being
sent to the chat panel instead of the main video as intended.