### PR TITLE
fix(mobile): bug in parsing caps properties

### DIFF
--- a/src/test/java/org/jitsi/meet/test/mobile/AndroidParticipantBuilder.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/AndroidParticipantBuilder.java
@@ -38,12 +38,14 @@ public class AndroidParticipantBuilder extends MobileParticipantBuilder
      * The name of Appium capability which tells the Appium driver which
      * activity should it expect when the app starts.
      */
-    private static final String CAPS_WAIT_ACTIVITY = "appWaitActivity";
+    private static final String CAPS_WAIT_ACTIVITY
+        = _CAPS_PROP_PREFIX + "appWaitActivity";
 
     /**
      * The package name of the wait activity. See {@link #CAPS_WAIT_ACTIVITY}.
      */
-    private static final String CAPS_WAIT_PACKAGE = "appWaitPackage";
+    private static final String CAPS_WAIT_PACKAGE
+        = _CAPS_PROP_PREFIX + "appWaitPackage";
 
     /**
      * Holds default config properties set for all Android participant builders.

--- a/src/test/java/org/jitsi/meet/test/mobile/MobileParticipantBuilder.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/MobileParticipantBuilder.java
@@ -267,7 +267,7 @@ public abstract class MobileParticipantBuilder
         {
             // When the value is set to the capabilities object, the "caps."
             // property prefix needs to be stripped out.
-            key = key.substring(0, _CAPS_PROP_PREFIX.length());
+            key = key.substring(_CAPS_PROP_PREFIX.length());
 
             capabilities.setCapability(key, propValue);
         }


### PR DESCRIPTION
App wait/package properties did not have the prefix. The capabilities
key was not stripped out of the prefix correctly. It worked, because
the two issues were present both at the same time, but i t was not
possible to override those capabilities.