### PR TITLE
ref: Disable TURN by default.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
@@ -37,6 +37,7 @@ public class WebTestBase
         + "&config.callStatsID=false"
         + "&config.alwaysVisibleToolbar=true"
         + "&config.p2p.enabled=false"
+        + "&config.p2p.useStunTurn=false"
         + "&config.gatherStats=true"
         + "&config.disable1On1Mode=true";
 


### PR DESCRIPTION
Our tests up till now have been working without TURN (our test deployments didn't have TURN support). Beta now as a TURN server because of the new bandwidth estimation test. This change might break some tests if left enabled by default.