### PR TITLE
ref(PermissionsAlert): search by id

### DIFF
--- a/src/test/java/org/jitsi/meet/test/pageobjects/mobile/permissions/PermissionsAlert.java
+++ b/src/test/java/org/jitsi/meet/test/pageobjects/mobile/permissions/PermissionsAlert.java
@@ -31,13 +31,10 @@ import org.jitsi.meet.test.pageobjects.mobile.base.*;
 public class PermissionsAlert extends AbstractMobilePage
 {
     @AndroidFindBy(
-        xpath
-            = "//android.widget.Button["
-            + "@resource-id="
-            + "'com.android.packageinstaller:id/permission_allow_button']"
+        id = "com.android.packageinstaller:id/permission_allow_button"
     )
     @iOSFindBy(
-        xpath = "//XCUIElementTypeButton[@name='OK']"
+        id = "OK"
     )
     private MobileElement allowButton;
 


### PR DESCRIPTION
It turns out that the xpath search was actually doing a search by id (@resource-id == id on Android, @name == id on iOS).