### PR TITLE
fix(Properties): do not use new Properties(properties)

### DIFF
--- a/src/test/java/org/jitsi/meet/test/base/AbstractBaseTest.java
+++ b/src/test/java/org/jitsi/meet/test/base/AbstractBaseTest.java
@@ -158,7 +158,9 @@ public abstract class AbstractBaseTest
         Map<String, String> params
             = context.getSuite().getXmlSuite().getAllParameters();
 
-        Properties output = new Properties(config);
+        Properties output = new Properties();
+
+        output.putAll(config);
 
         params.forEach(output::setProperty);
 

--- a/src/test/java/org/jitsi/meet/test/base/TestSettings.java
+++ b/src/test/java/org/jitsi/meet/test/base/TestSettings.java
@@ -53,9 +53,12 @@ public class TestSettings
                 throw new RuntimeException("Missing settings.properties file.");
             }
 
+            Properties p = new Properties();
+
             // take current system properties as we will set merged props
             // to system
-            Properties p = new Properties(System.getProperties());
+            p.putAll(System.getProperties());
+
             p.load(is);
 
             // setting system properties


### PR DESCRIPTION
This is not a copying constructor - it will put the properties as
defaults which are treated in a special way by Properties's methods.
You can not remove a default property for example. They are also not
visible when debugging in some IDEs.

https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#Properties(java.util.Properties)