### PR TITLE
fix(AndroidParticipantOptions): provide default app/package

### DIFF
--- a/src/test/java/org/jitsi/meet/test/mobile/MobileParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/MobileParticipant.java
@@ -48,7 +48,7 @@ public class MobileParticipant extends Participant<AppiumDriver<WebElement>>
      * The full path to the binary file which can be used to install the app on
      * the device.
      */
-    private final String app;
+    private final String appBinaryFile;
 
     /**
      * The conference view instance.
@@ -73,19 +73,19 @@ public class MobileParticipant extends Participant<AppiumDriver<WebElement>>
      * @param type - The participant's type.
      * @param appBundleId - The app bundle identifies which can be used to
      * start/uninstall the app.
-     * @param app - A full path to the app binary file which can be used to
-     * install the app on the device.
+     * @param appBinaryFile - A full path to the app binary file which can be
+     * used to install the app on the device.
      */
     public MobileParticipant(AppiumDriver<WebElement> driver,
                              String name,
                              ParticipantType type,
                              String appBundleId,
-                             String app)
+                             String appBinaryFile)
     {
         super(name, driver, type);
         this.driver = Objects.requireNonNull(driver, "driver");
         this.appBundleId = Objects.requireNonNull(appBundleId, "appBundleId");
-        this.app = Objects.requireNonNull(app, "app");
+        this.appBinaryFile = appBinaryFile;
     }
 
     /**
@@ -330,7 +330,7 @@ public class MobileParticipant extends Participant<AppiumDriver<WebElement>>
             Logger.getGlobal().log(Level.INFO, "Removing app...");
             driver.removeApp(appBundleId);
             Logger.getGlobal().log(Level.INFO, "Installing app...");
-            driver.installApp(app);
+            driver.installApp(appBinaryFile);
             Logger.getGlobal().log(Level.INFO, "Launching app...");
             driver.launchApp();
         }

--- a/src/test/java/org/jitsi/meet/test/mobile/base/AndroidParticipantOptions.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/base/AndroidParticipantOptions.java
@@ -35,6 +35,21 @@ public class AndroidParticipantOptions
     private static final String ANDROID_PLATFORM_NAME = "android";
 
     /**
+     * If the {@link #CAPS_APP} is not an .apk file then Android driver will
+     * require both {@code #CAPS_ACTIVITY} and {@link #CAPS_PACKAGE} to be
+     * specified in order to run the app without installation (which will work
+     * if the app is on the device already).
+     */
+    private static final String CAPS_ACTIVITY
+        = _CAPS_PROP_PREFIX + "appActivity";
+
+    /**
+     * Specifies the Android's app package name. Required to be specified if
+     * the {@link #CAPS_APP} is missing.
+     */
+    private static final String CAPS_PACKAGE = _CAPS_PROP_PREFIX + "appPackage";
+
+    /**
      * The name of Appium capability which tells the Appium driver which
      * activity should it expect when the app starts.
      */
@@ -46,6 +61,11 @@ public class AndroidParticipantOptions
      */
     private static final String CAPS_WAIT_PACKAGE
         = _CAPS_PROP_PREFIX + "appWaitPackage";
+
+    /**
+     * The default value for {@link #CAPS_ACTIVITY}.
+     */
+    private static final String DEFAULT_ACTIVITY = ".MainActivity";
 
     /**
      * Default Android bundle ID of the app being tested.
@@ -75,6 +95,8 @@ public class AndroidParticipantOptions
     {
         DesiredCapabilities capabilities = super.createCapabilities();
 
+        readAndSetCapability(capabilities, CAPS_ACTIVITY);
+        readAndSetCapability(capabilities, CAPS_PACKAGE);
         readAndSetCapability(capabilities, CAPS_WAIT_ACTIVITY);
         readAndSetCapability(capabilities, CAPS_WAIT_PACKAGE);
 
@@ -89,6 +111,10 @@ public class AndroidParticipantOptions
     {
         Properties defaults = super.initDefaults();
 
+        defaults.setProperty(
+                CAPS_ACTIVITY, DEFAULT_ACTIVITY);
+        defaults.setProperty(
+                CAPS_PACKAGE, DEFAULT_BUNDLE_ID);
         defaults.setProperty(
                 CAPS_PLATFORM_NAME, ANDROID_PLATFORM_NAME);
         defaults.setProperty(


### PR DESCRIPTION
It turns out that Android driver will not simply accept the package name
as the "app" capability to run the app if it comes pre-installed on
the device (in contrary to what the iOS driver does). Because of that we
need to provide default values for both package and activity
capabilities.

Rename the MobileParticipant's app field to something more meaningful.