### PR TITLE
feat(toolbar): new page object for new toolbar

### DIFF
--- a/src/test/java/org/jitsi/meet/test/AvatarTest.java
+++ b/src/test/java/org/jitsi/meet/test/AvatarTest.java
@@ -284,7 +284,9 @@ public class AvatarTest
             driver1,
             5,
             (ExpectedCondition<Boolean>) d
-                -> getSrcByXPath(driver1, "//img[@id='avatar']")
+                -> participant1.getToolbar()
+                        .getProfileImage()
+                        .getAttribute("src")
                         .contains(HASH));
 
         //check if the avatar in the local thumbnail has changed

--- a/src/test/java/org/jitsi/meet/test/ContactListTest.java
+++ b/src/test/java/org/jitsi/meet/test/ContactListTest.java
@@ -21,6 +21,7 @@ import org.jitsi.meet.test.web.*;
 
 import org.openqa.selenium.*;
 import org.openqa.selenium.support.ui.*;
+import org.testng.*;
 import org.testng.annotations.*;
 
 import static org.testng.Assert.*;
@@ -53,6 +54,11 @@ public class ContactListTest
     public void testContactList()
     {
         WebParticipant participant1 = getParticipant1();
+
+        if (participant1.getToolbar().isNewToolbar()) {
+            throw new SkipException(
+                "Contact list no supported in new toolbox. Disabling test.");
+        }
 
         // Make sure that the contact list panel is open.
         MeetUIUtils.displayContactListPanel(participant1);

--- a/src/test/java/org/jitsi/meet/test/ContactListTest.java
+++ b/src/test/java/org/jitsi/meet/test/ContactListTest.java
@@ -57,7 +57,7 @@ public class ContactListTest
 
         if (participant1.getToolbar().isNewToolbar()) {
             throw new SkipException(
-                "Contact list no supported in new toolbox. Disabling test.");
+                "Contact list not supported in new toolbox. Disabling test.");
         }
 
         // Make sure that the contact list panel is open.

--- a/src/test/java/org/jitsi/meet/test/FilmstripOnlyTest.java
+++ b/src/test/java/org/jitsi/meet/test/FilmstripOnlyTest.java
@@ -61,12 +61,7 @@ public class FilmstripOnlyTest
             "//span[@id='participant_" + participant2EndpointId + "']",
             5);
 
-        // The toolbox should display.
-        TestUtils.waitForDisplayedElementByXPath(
-            driver1,
-            "//div[contains(@class, 'toolbox')]",
-            5
-        );
+        getParticipant1().getToolbar().waitForVisible();
     }
 
     /**

--- a/src/test/java/org/jitsi/meet/test/OneOnOneTest.java
+++ b/src/test/java/org/jitsi/meet/test/OneOnOneTest.java
@@ -45,7 +45,6 @@ public class OneOnOneTest
     private static final String ONE_ON_ONE_CONFIG_OVERRIDES
         = "config.disable1On1Mode=false"
         + "&interfaceConfig.TOOLBAR_TIMEOUT=250"
-        + "&interfaceConfig.INITIAL_TOOLBAR_TIMEOUT=250"
         + "&config.alwaysVisibleToolbar=false";
 
     /**
@@ -63,8 +62,8 @@ public class OneOnOneTest
 
         // Prevent toolbar from being always displayed as filmstrip visibility
         // is tied to toolbar visibility.
-        stopDockingToolbar(participant1);
-        stopDockingToolbar(participant2);
+        configureToolbarsToHideQuickly(participant1);
+        configureToolbarsToHideQuickly(participant2);
 
         verifyRemoteVideosDisplay(participant1, false);
         verifyRemoteVideosDisplay(participant2, false);
@@ -81,7 +80,7 @@ public class OneOnOneTest
             getJitsiMeetUrl().appendConfig(ONE_ON_ONE_CONFIG_OVERRIDES));
 
         WebParticipant participant3 = getParticipant3();
-        stopDockingToolbar(participant3);
+        configureToolbarsToHideQuickly(participant3);
 
         verifyRemoteVideosDisplay(getParticipant1(), true);
         verifyRemoteVideosDisplay(getParticipant2(), true);
@@ -148,8 +147,6 @@ public class OneOnOneTest
     private void verifyRemoteVideosDisplay(
         Participant testee, boolean isDisplayed)
     {
-        waitForToolbarsHidden(testee);
-
         String filmstripRemoteVideosXpath
             = "//div[@id='filmstripRemoteVideosContainer']";
 
@@ -161,33 +158,15 @@ public class OneOnOneTest
     }
 
     /**
-     * Disables permanent display (docking) of the toolbars.
+     * Disables permanent display (docking) of the toolbars and sets toolbars
+     * to be dismissed more quickly.
      *
      * @param testee the <tt>WebDriver</tt> of the participant for whom we're
      *               no longer want to dock toolbars.
-
      */
-    private void stopDockingToolbar(WebParticipant testee)
+    private void configureToolbarsToHideQuickly(WebParticipant testee)
     {
         testee.executeScript("APP.UI.dockToolbar(false);");
-    }
-
-    /**
-     * Waits until the toolbars are no longer displayed.
-     *
-     * @param testee the <tt>WebDriver</tt> of the participant for whom we're
-     *               waiting to no longer see toolbars.
-     */
-    private void waitForToolbarsHidden(Participant testee)
-    {
-        // Wait for the visible filmstrip to no longer be displayed.
-        String visibleToolbarXpath
-            = "//*[contains(@class, 'toolbar_secondary')"
-            + "and contains(@class ,'slideInExtX')]";
-
-        TestUtils.waitForElementNotPresentByXPath(
-            testee.getDriver(),
-            visibleToolbarXpath,
-            FILMSTRIP_VISIBILITY_WAIT);
+        testee.executeScript("APP.UI.showToolbar(250);");
     }
 }

--- a/src/test/java/org/jitsi/meet/test/RingOverlayTest.java
+++ b/src/test/java/org/jitsi/meet/test/RingOverlayTest.java
@@ -113,8 +113,7 @@ public class RingOverlayTest
         // these are display name, email and avatar
         String emailInput = "//input[@id='setEmail']";
         // wait for the toolbar to be visible before clicking on it
-        TestUtils.waitForDisplayedElementByXPath(
-            driver1, "//div[contains(@class, 'toolbar_secondary')]", 3);
+        getParticipant1().getToolbar().waitForVisible();
         getParticipant1().getToolbar().clickProfileButton();
         TestUtils.waitForDisplayedElementByXPath(
             driver1, emailInput, 5);
@@ -127,11 +126,12 @@ public class RingOverlayTest
                 .getAttribute("value"),
             USER_NAME);
 
-        assertEquals(
-            driver1.findElement(By.xpath(
-                    "//div[contains(@class, 'toolbar_secondary')]//img[@id='avatar']"))
-                .getAttribute("src"),
-            USER_AVATAR_URL);
+        String profileImageSRC = getParticipant1()
+            .getToolbar()
+            .getProfileImage()
+            .getAttribute("src");
+
+        assertEquals(profileImageSRC, USER_AVATAR_URL);
 
         // now let's join a second participant and check that there is no
         // ring overlay and the second participant sees the same display name

--- a/src/test/java/org/jitsi/meet/test/SwitchVideoTest.java
+++ b/src/test/java/org/jitsi/meet/test/SwitchVideoTest.java
@@ -72,6 +72,7 @@ public class SwitchVideoTest
     @Test(dependsOnMethods = {"participant1ClickOnLocalVideoAndTest"})
     public void participant1ClickOnRemoteVideoAndTest()
     {
+        getParticipant1().getToolbar().closeOverflowMenu();
         MeetUIUtils.selectRemoteVideo(
             getParticipant1().getDriver(),
             getParticipant2().getEndpointId());

--- a/src/test/java/org/jitsi/meet/test/pageobjects/web/Toolbar.java
+++ b/src/test/java/org/jitsi/meet/test/pageobjects/web/Toolbar.java
@@ -54,6 +54,7 @@ public class Toolbar {
      * Xpaths to be used as selectors for finding WebElements within the
      * {@link Toolbar}.
      */
+    private final static String AVATAR_IMAGE_XPATH = "//img[@id='avatar']";
     private final static String DS_BUTTON_XPATH
         = "//a[@id='" + DS_BUTTON_ID + "']";
 
@@ -257,7 +258,28 @@ public class Toolbar {
     }
 
     /**
-     * Returns whether or not the recording button is present in the toolbar.
+     * Ensures the overflow menu is closed.
+     */
+    public void closeOverflowMenu() {
+        // This method is intentionally not implemented. This Class in general
+        // is temporary while converting tests to use ToolbarV2.
+    }
+
+    /**
+     * Gets the participant's avatar image element located in the toolbar.
+     *
+     * @return <tt>WebElement</tt> for the toolbar profile image.
+     */
+    public WebElement getProfileImage()
+    {
+        return participant.getDriver().findElement(
+            By.xpath(AVATAR_IMAGE_XPATH));
+    }
+
+    /**
+     * Checks whether or not the recording button is present in the toolbar.
+     *
+     * @return A boolean for whether or not the recording button is present.
      */
     public boolean hasRecordButton()
     {
@@ -265,6 +287,17 @@ public class Toolbar {
             By.id(RECORD_BUTTON_ID));
 
         return !elements.isEmpty();
+    }
+
+    /**
+     * Returns whether or not this the participant is using the new toolbar.
+     * This method is used to help transition tests over to the new toolbar.
+     *
+     * @return false to indicate this is the old toolbar.
+     */
+    public boolean isNewToolbar()
+    {
+        return false;
     }
 
     /**
@@ -289,5 +322,16 @@ public class Toolbar {
             participant.getDriver(),
             VIDEO_MUTE_BUTTON_ID,
             10);
+    }
+
+    /**
+     * Waits up to 3 seconds for the the toolbar to be visible on the page.
+     */
+    public void waitForVisible()
+    {
+        TestUtils.waitForDisplayedElementByXPath(
+            participant.getDriver(),
+            "//div[contains(@class, 'toolbar')]",
+            3);
     }
 }

--- a/src/test/java/org/jitsi/meet/test/pageobjects/web/ToolbarV2.java
+++ b/src/test/java/org/jitsi/meet/test/pageobjects/web/ToolbarV2.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright @ 2018 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.meet.test.pageobjects.web;
+
+import org.jitsi.meet.test.util.*;
+import org.jitsi.meet.test.web.*;
+import org.openqa.selenium.*;
+
+import java.util.*;
+
+/**
+ * Represents the toolbar in a particular {@link WebParticipant}.
+ *
+ * @author Leonard Kim
+ */
+public class ToolbarV2 extends Toolbar {
+    /**
+     * Accessibility labels to be used as selectors for finding WebElements
+     * within the {@link ToolbarV2}.
+     */
+    private final static String AUDIO_MUTE = "Audio mute";
+    private final static String CHAT = "Chat";
+    private final static String DESKTOP = "Screenshare";
+    private final static String ETHERPAD = "Etherpad";
+    private final static String HANGUP = "Hangup";
+    private final static String INFO = "Info";
+    private final static String OVERFLOW = "Overflow";
+    private final static String OVERFLOW_MENU = "Overflow menu";
+    private final static String PROFILE = "Profile";
+    private final static String RECORD = "Record";
+    private final static String SETTINGS = "Settings";
+    private final static String SHARE_VIDEO = "Shared video";
+    private final static String VIDEO_MUTE = "Video mute";
+    private final static String VIDEO_QUALITY = "Call quality";
+
+    /**
+     * The ID of the toolbar. To be used as a selector when trying to locate
+     * the toolbar on the page.
+     */
+    private final static String TOOLBOX_ID = "new-toolbox";
+
+    /**
+     * The xpath for the desktop button icon. Its toggle class can determine
+     * if desktop sharing is active or not active.
+     */
+    private final static String DESKTOP_ICON_XPATH
+        = "//i[contains(@class, 'icon-share-desktop')]";
+
+    /**
+     * The participant.
+     */
+    private final WebParticipant participant;
+
+    /**
+     * Initializes a new {@link Toolbar} instance.
+     *
+     * @param participant the participant for this {@link Toolbar}.
+     */
+    public ToolbarV2(WebParticipant participant)
+    {
+        super(participant);
+
+        this.participant = Objects.requireNonNull(participant, "participant");
+    }
+
+    /**
+     * Clicks on the microphone mute toolbar button, which toggles audio mute.
+     */
+    public void clickAudioMuteButton()
+    {
+        clickButton(AUDIO_MUTE);
+    }
+
+    /**
+     * Clicks on the "desktop sharing" toolbar button. Fails if the button
+     * doesn't exist or if the toggled state is not changed after the click.
+     */
+    public void clickDesktopSharingButton()
+    {
+        WebDriver driver = participant.getDriver();
+
+        waitForButtonDisplay(DESKTOP);
+
+        WebElement desktopIcon = driver.findElement(By.cssSelector(
+            getAccessibilityCSSSelector(DESKTOP_ICON_XPATH)));
+        String classNames = desktopIcon.getAttribute("class");
+        boolean isToggled = classNames.contains("toggled");
+
+        clickButton(DESKTOP);
+
+        if (isToggled)
+        {
+            TestUtils.waitForElementNotContainsClassByXPath(
+                driver,
+                DESKTOP_ICON_XPATH,
+                "toggled",
+                2);
+        }
+        else
+        {
+            TestUtils.waitForElementContainsClassByXPath(
+                driver,
+                DESKTOP_ICON_XPATH,
+                "toggled",
+                2);
+        }
+    }
+
+    /**
+     * Clicks on the "chat" toolbar button which opens or closes the chat panel.
+     */
+    public void clickChatButton()
+    {
+        clickButton(CHAT);
+    }
+
+    /**
+     * Clicks on the etherpad toolbar button which shows or hides etherpad.
+     */
+    public void clickEtherpadButton()
+    {
+        clickButtonInOverflowMenu(ETHERPAD);
+    }
+
+    /**
+     * Clicks on the settings toolbar button which opens the device selection
+     * popup.
+     */
+    public void clickFilmstripOnlySettingsButton()
+    {
+        clickButton(SETTINGS);
+    }
+
+    /**
+     * Clicks on the hangup toolbar button which leaves the current conference.
+     */
+    public void clickHangUpButton()
+    {
+        attemptToClickButton(HANGUP);
+    }
+
+    /**
+     * Clicks on the info toolbar button which opens or closes the info dialog.
+     */
+    public void clickInfoButton()
+    {
+        clickButton(INFO);
+    }
+
+    /**
+     * Clicks on the overflow toolbar button which opens or closes the overflow
+     * menu.
+     */
+    public void clickOverflowButton() {
+        clickButton(OVERFLOW);
+    }
+
+    /**
+     * Clicks on the profile toolbar button which opens or closes the profile
+     * panel.
+     */
+    public void clickProfileButton()
+    {
+        clickButtonInOverflowMenu(PROFILE);
+    }
+
+    /**
+     * Clicks on the recording toolbar button which toggles recording or live
+     * streaming.
+     */
+    public void clickRecordButton()
+    {
+        clickButtonInOverflowMenu(RECORD);
+    }
+
+    /**
+     * Clicks on the settings toolbar button which opens or closes the settings
+     * panel.
+     */
+    public void clickSettingsButton()
+    {
+        clickButtonInOverflowMenu(SETTINGS);
+    }
+
+    /**
+     * Clicks on the shared video toolbar button which toggles sharing of a
+     * YouTube video.
+     */
+    public void clickSharedVideoButton()
+    {
+        clickButtonInOverflowMenu(SHARE_VIDEO);
+    }
+
+    /**
+     * Clicks on the video mute toolbar button which toggles video mute.
+     */
+    public void clickVideoMuteButton()
+    {
+        clickButton(VIDEO_MUTE);
+    }
+
+    /**
+     * Clicks on the video quality toolbar button which opens or closes the
+     * dialog for adjusting max-received video quality.
+     */
+    public void clickVideoQualityButton()
+    {
+        clickButtonInOverflowMenu(VIDEO_QUALITY);
+    }
+
+    /**
+     * Ensures the overflow menu is not displayed.
+     */
+    public void closeOverflowMenu()
+    {
+        if (!isOverflowMenuOpen())
+        {
+            return;
+        }
+
+        clickOverflowButton();
+    }
+
+    /**
+     * Gets the participant's avatar image element located in the toolbar.
+     *
+     * @return <tt>WebElement</tt> for the toolbar profile image.
+     */
+    public WebElement getProfileImage()
+    {
+        openOverflowMenu();
+
+        return participant.getDriver().findElement(By.cssSelector(
+            getAccessibilityCSSSelector(PROFILE) + " img"));
+    }
+
+    /**
+     * Checks whether or not the recording button is present in the toolbar.
+     *
+     * @return True if the recording button is present, false if it is not.
+     */
+    public boolean hasRecordButton()
+    {
+        openOverflowMenu();
+
+        List<WebElement> elements
+            = participant.getDriver().findElements(By.cssSelector(
+                getAccessibilityCSSSelector(RECORD)));
+
+        return !elements.isEmpty();
+    }
+
+    /**
+     * Returns whether or not this the participant is using the new toolbar.
+     * This method is used to help transition tests over to the new toolbar.
+     *
+     * @return true to indicate this is the new toolbar.
+     */
+    public boolean isNewToolbar()
+    {
+        return true;
+    }
+
+    /**
+     * Checks if the overflow menu is open and visible.
+     *
+     * @return True if the overflow menu is visible, false if it is not.
+     */
+    public boolean isOverflowMenuOpen()
+    {
+        List<WebElement> elements = participant.getDriver().findElements(
+            getOverflowMenuSelector());
+
+        return !elements.isEmpty();
+    }
+
+    /**
+     * Ensure the overflow menu is displayed.
+     */
+    public void openOverflowMenu()
+    {
+        if (isOverflowMenuOpen())
+        {
+            return;
+        }
+
+        clickOverflowButton();
+
+        TestUtils.waitForElementBy(
+            participant.getDriver(),
+            getOverflowMenuSelector(),
+            5);
+    }
+
+    /**
+     * Waits up to 10 seconds for the shared video button in the toolbar to be
+     * visible.
+     */
+    public void waitForSharedVideoButtonDisplay()
+    {
+        clickButtonInOverflowMenu(SHARE_VIDEO);
+    }
+
+    /**
+     * Waits up to 10 seconds for the video mute button in the toolbar to be
+     * visible.
+     */
+    public void waitForVideoMuteButtonDisplay()
+    {
+        waitForButtonDisplay(VIDEO_MUTE);
+    }
+
+    /**
+     * Waits up to 3 seconds for the toolbar to be visible.
+     */
+    public void waitForVisible()
+    {
+        TestUtils.waitForDisplayedElementByID(
+            participant.getDriver(),
+            TOOLBOX_ID,
+            3);
+    }
+
+    /**
+     * Try to click on a button but do not fail if it is not clickable.
+     *
+     * @param accessibilityLabel The accessibility label of the button to be
+     * clicked.
+     */
+    private void attemptToClickButton(String accessibilityLabel)
+    {
+        MeetUIUtils.clickOnElement(
+            participant.getDriver(),
+            getAccessibilityCSSSelector(accessibilityLabel),
+            false
+        );
+    }
+
+    /**
+     * Try to click on a button and fail if it cannot be clicked.
+     *
+     * @param accessibilityLabel The accessibility label of the button to be
+     * clicked.
+     */
+    private void clickButton(String accessibilityLabel)
+    {
+        MeetUIUtils.clickOnElement(
+            participant.getDriver(),
+            getAccessibilityCSSSelector(accessibilityLabel),
+            true
+        );
+    }
+
+    /**
+     * Ensure the overflow menu is open and clicks on a specified button.
+     *
+     * @param accessibilityLabel The accessibility label of the button to be
+     * clicked.
+     */
+    private void clickButtonInOverflowMenu(String accessibilityLabel)
+    {
+        openOverflowMenu();
+
+        clickButton(accessibilityLabel);
+    }
+
+    /**
+     * Helper for formatting the string to be used as a CSS selector for
+     * an accessibility label.
+     *
+     * @param accessibilityLabel The accessibility label to be used to search
+     * for a WebElement on the page.
+     * @return String intended to be used with By#cssSelector.
+     */
+    private String getAccessibilityCSSSelector(String accessibilityLabel)
+    {
+        return String.format("[aria-label=\"%s\"]", accessibilityLabel);
+    }
+
+    /**
+     * Helper for retrieving the selector for the overflow menu.
+     *
+     * @return <tt>By</tt> to be used by WebDriver to locate the overflow menu.
+     */
+    private By getOverflowMenuSelector()
+    {
+        return By.cssSelector(getAccessibilityCSSSelector(OVERFLOW_MENU));
+    }
+
+    /**
+     * Waits up to 10 seconds for a button to be visible on the toolbar.
+     *
+     * @param accessibilityLabel The accessibility label of the button to be
+     * clicked.
+     */
+    private void waitForButtonDisplay(String accessibilityLabel)
+    {
+        TestUtils.waitForElementBy(
+            participant.getDriver(),
+            By.cssSelector(getAccessibilityCSSSelector(accessibilityLabel)),
+            10);
+    }
+}

--- a/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
@@ -498,8 +498,8 @@ public class WebParticipant extends Participant<WebDriver>
     {
         if (toolbar == null)
         {
-            boolean usingNewToolbar = (boolean) executeScript
-                ("return interfaceConfig._USE_NEW_TOOLBOX");
+            boolean usingNewToolbar = (boolean) executeScript (
+                "return interfaceConfig._USE_NEW_TOOLBOX");
 
             if (usingNewToolbar) {
                 toolbar = new ToolbarV2(this);

--- a/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
@@ -498,7 +498,14 @@ public class WebParticipant extends Participant<WebDriver>
     {
         if (toolbar == null)
         {
-            toolbar = new Toolbar(this);
+            boolean usingNewToolbar = (boolean) executeScript
+                ("return interfaceConfig._USE_NEW_TOOLBOX");
+
+            if (usingNewToolbar) {
+                toolbar = new ToolbarV2(this);
+            } else {
+                toolbar = new Toolbar(this);
+            }
         }
 
         return toolbar;

--- a/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
@@ -40,7 +40,7 @@ public class WebTestBase
         + "&config.p2p.useStunTurn=false"
         + "&config.gatherStats=true"
         + "&config.disable1On1Mode=true"
-        + "&interfaceConfig._USE_NEW_TOOLBOX=false";
+        + "&interfaceConfig._USE_NEW_TOOLBOX=true";
 
     /**
      * Default


### PR DESCRIPTION
I've left in the old toolbar page object. I'll be getting rid of it when the old toolbar is removed from jitsi-meet. I suppose as long as the old toolbar exists I'd prefer to keep it present so it's testable.