### PR TITLE
Fix join conference Android 8

### DIFF
--- a/src/test/java/org/jitsi/meet/test/mobile/MobileParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/MobileParticipant.java
@@ -249,9 +249,16 @@ public class MobileParticipant extends Participant<AppiumDriver<WebElement>>
 
         if (type.isAndroid())
         {
-            driver.hideKeyboard();
 
-            welcomePageView.getJoinRoomButton().click();
+            // FIXME The 3 clicks below is a hack to workaround a bug in Jitsi
+            // Meet UI where the focus is lost after the first click.
+            // To be removed once the bug mentioned above is fixed (I don't know
+            // how to fix it).
+            roomNameInput.click();
+            roomNameInput.click();
+            roomNameInput.click();
+
+            getAndroidDriver().pressKeyCode(AndroidKeyCode.ENTER);
         }
         else
         {

--- a/src/test/java/org/jitsi/meet/test/mobile/base/MobileParticipantOptions.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/base/MobileParticipantOptions.java
@@ -42,6 +42,12 @@ public class MobileParticipantOptions
     static final String CAPS_APP = _CAPS_PROP_PREFIX + "app";
 
     /**
+     * The property key for Appium's "automationName" capability.
+     */
+    private static final String CAPS_AUTOMATION_NAME
+        = _CAPS_PROP_PREFIX + "automationName";
+
+    /**
      * The property key for Appium's "deviceName" capability.
      */
     private static final String CAPS_DEVICE_NAME
@@ -99,6 +105,7 @@ public class MobileParticipantOptions
         DesiredCapabilities capabilities = new DesiredCapabilities();
 
         readAndSetCapability(capabilities, CAPS_APP);
+        readAndSetCapability(capabilities, CAPS_AUTOMATION_NAME);
         readAndSetCapability(capabilities, CAPS_PLATFORM_NAME);
         readAndSetCapability(capabilities, CAPS_DEVICE_NAME);
 


### PR DESCRIPTION
On newer Android phones the old UI automator does not find the "conference" element after entering the room. See commit msg for more details.