### PR TITLE
fix(Android): can not find "conference" element

### DIFF
--- a/src/test/java/org/jitsi/meet/test/mobile/MobileParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/MobileParticipant.java
@@ -35,7 +35,7 @@ import java.util.logging.*;
  *
  * @author Pawel Domas
  */
-public class MobileParticipant extends Participant<AppiumDriver<WebElement>>
+public class MobileParticipant extends Participant<AppiumDriver<MobileElement>>
 {
     /**
      * The default config part of the {@link JitsiMeetUrl} for every mobile
@@ -72,7 +72,7 @@ public class MobileParticipant extends Participant<AppiumDriver<WebElement>>
     /**
      * The Appium driver instance.
      */
-    private final AppiumDriver<WebElement> driver;
+    private final AppiumDriver<MobileElement> driver;
 
     /**
      * Initializes {@link MobileParticipant}.
@@ -86,7 +86,7 @@ public class MobileParticipant extends Participant<AppiumDriver<WebElement>>
      * @param appBinaryFile - A full path to the app binary file which can be
      * used to install the app on the device.
      */
-    public MobileParticipant(AppiumDriver<WebElement> driver,
+    public MobileParticipant(AppiumDriver<MobileElement> driver,
                              String name,
                              ParticipantType type,
                              String appBundleId,
@@ -119,9 +119,9 @@ public class MobileParticipant extends Participant<AppiumDriver<WebElement>>
         }
     }
 
-    private AndroidDriver<WebElement> getAndroidDriver()
+    private AndroidDriver<MobileElement> getAndroidDriver()
     {
-        return type.isAndroid() ? (AndroidDriver<WebElement>) driver : null;
+        return type.isAndroid() ? (AndroidDriver<MobileElement>) driver : null;
     }
 
     /**
@@ -276,7 +276,7 @@ public class MobileParticipant extends Participant<AppiumDriver<WebElement>>
         ConferenceView conference = new ConferenceView(this);
 
         // Just to make sure we're in the conference
-        conference.getRootView().getText();
+        conference.getLargeVideo().getValue();
     }
 
     /**
@@ -321,7 +321,7 @@ public class MobileParticipant extends Participant<AppiumDriver<WebElement>>
     /**
      * {@inheritDoc}
      */
-    public AppiumDriver<WebElement> getDriver()
+    public AppiumDriver<MobileElement> getDriver()
     {
         return driver;
     }

--- a/src/test/java/org/jitsi/meet/test/mobile/base/MobileParticipantFactory.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/base/MobileParticipantFactory.java
@@ -20,7 +20,6 @@ import io.appium.java_client.android.*;
 import io.appium.java_client.ios.*;
 import org.jitsi.meet.test.base.*;
 import org.jitsi.meet.test.mobile.*;
-import org.openqa.selenium.*;
 import org.openqa.selenium.remote.*;
 
 import java.net.*;
@@ -77,7 +76,7 @@ public class MobileParticipantFactory
         URL appiumUrl = targetOptions.getAppiumServerUrl();
         DesiredCapabilities capabilities = targetOptions.createCapabilities();
 
-        AppiumDriver<WebElement> driver
+        AppiumDriver<MobileElement> driver
             = type.isAndroid()
                 ? new AndroidDriver<>(appiumUrl, capabilities)
                 : new IOSDriver<>(appiumUrl, capabilities);

--- a/src/test/java/org/jitsi/meet/test/pageobjects/base/TestHint.java
+++ b/src/test/java/org/jitsi/meet/test/pageobjects/base/TestHint.java
@@ -37,7 +37,7 @@ public class TestHint
     /**
      * The mobile participant's driver.
      */
-    private final AppiumDriver driver;
+    private final AppiumDriver<MobileElement> driver;
 
     /**
      * The test hint's id (key).
@@ -51,10 +51,34 @@ public class TestHint
      * @param id - The test hint's id (key) which identifies a hint in the app's
      * scope.
      */
-    public TestHint(AppiumDriver driver, String id)
+    public TestHint(AppiumDriver<MobileElement> driver, String id)
     {
         this.driver = driver;
         this.id = id;
+    }
+
+    /**
+     * Clicks on the {@link TestHint} which should execute the 'onPress' handler
+     * bound on the JavaScript side.
+     */
+    public void click()
+    {
+        getElement().click();
+    }
+
+    /**
+     * Finds the underlying {@link MobileElement} for this {@link TestHint}
+     * instance.
+     *
+     * @return {@link MobileElement}
+     * @throws NoSuchElementException if {@link MobileElement} could not be
+     * found on the current screen.
+     */
+    private MobileElement getElement()
+    {
+        return useAccessibilityForId()
+            ? driver.findElementByAccessibilityId(id)
+            : driver.findElementById(id);
     }
 
     /**
@@ -67,12 +91,7 @@ public class TestHint
      */
     public String getValue()
     {
-        WebElement element
-            = useAccessibilityForId()
-                ? driver.findElementByAccessibilityId(id)
-                : driver.findElementById(id);
-
-        return element.getText();
+        return getElement().getText();
     }
 
     /**

--- a/src/test/java/org/jitsi/meet/test/pageobjects/mobile/ConferenceView.java
+++ b/src/test/java/org/jitsi/meet/test/pageobjects/mobile/ConferenceView.java
@@ -15,9 +15,6 @@
  */
 package org.jitsi.meet.test.pageobjects.mobile;
 
-import io.appium.java_client.*;
-import io.appium.java_client.pagefactory.*;
-
 import org.jitsi.meet.test.mobile.*;
 import org.jitsi.meet.test.pageobjects.base.*;
 import org.jitsi.meet.test.pageobjects.mobile.base.*;
@@ -28,17 +25,16 @@ import org.jitsi.meet.test.pageobjects.mobile.base.*;
 public class ConferenceView extends AbstractMobilePage
 {
     /**
-     * Root element with "Conference" accessibility label.
-     */
-    @AndroidFindBy(accessibility = "Conference")
-    @iOSFindBy(accessibility = "Conference")
-    private MobileElement conference;
-
-    /**
-     * Root element with "Conference" accessibility label.
+     * The conference name test hint.
      */
     @TestHintLocator(id = "org.jitsi.meet.conference.name")
     private TestHint conferenceName;
+
+    /**
+     * The large video test hint.
+     */
+    @TestHintLocator(id = "org.jitsi.meet.LargeVideo")
+    private TestHint largeVideo;
 
     private ToolbarView toolbar;
 
@@ -63,13 +59,13 @@ public class ConferenceView extends AbstractMobilePage
     }
 
     /**
-     * Tries to obtain root container of the conference view.
+     * Gets the large video {@link TestHint}.
      *
-     * @return a <tt>MobileElement</tt> proxy object.
+     * @return a {@link TestHint} instance for the "large video" element.
      */
-    public MobileElement getRootView()
+    public TestHint getLargeVideo()
     {
-        return conference;
+        return largeVideo;
     }
 
     /**

--- a/src/test/java/org/jitsi/meet/test/pageobjects/mobile/ToolbarView.java
+++ b/src/test/java/org/jitsi/meet/test/pageobjects/mobile/ToolbarView.java
@@ -80,7 +80,7 @@ public class ToolbarView extends AbstractMobilePage
     {
         if (!isOpen())
         {
-            conferenceView.getRootView().click();
+            conferenceView.getLargeVideo().click();
         }
     }
 }


### PR DESCRIPTION
Fixes a SetupConferenceTest failure on Android caused by the fact that there's no clickable "Conference" element in jitsi-meet.