### PR TITLE
Add timeout for persitency check before reload

### DIFF
--- a/src/test/java/org/jitsi/meet/test/DisplayNameTest.java
+++ b/src/test/java/org/jitsi/meet/test/DisplayNameTest.java
@@ -96,6 +96,9 @@ public class DisplayNameTest
 
         doLocalDisplayNameCheck(randomName);
 
+        // There is a max of 2 seconds delay in the persistency throttling
+        TestUtils.waitMillis(2000);
+
         // now let's reload the second participant
         getParticipant2().hangUp();
         ensureTwoParticipants();


### PR DESCRIPTION
This test randomly fails since the redux-based settings support on web. I think the reason is that the persistency layer has a 2 seconds throttling to avid overuse of localStorage and sometimes it just doesn't always get to run before the test browser is closed/reloaded.