### PR TITLE
Retry joining a muc on first failure.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
@@ -368,12 +368,20 @@ public class WebTestBase
     {
         WebParticipant participant = joinParticipant(index, meetURL, options);
 
+        // FIXME: remove this when chrome changes and we stop seeing the warning
+        // in the tests logs
         try
         {
             participant.waitToJoinMUC(10);
         }
         catch (TimeoutException ex)
         {
+            // workaround is only for chrome
+            if (!participant.getType().isChrome())
+            {
+                throw ex;
+            }
+
             Logger.getGlobal().log(
                 Level.WARNING,
                 "Participant did not join, retrying: " + participant.getName());


### PR DESCRIPTION
With latest chrome update (v66, v65) we see sometimes on screenshots and on video that the browser is stuck on the permissions screen and never joins the room. We skip the first wait to join failure and we retry second time.