### PR TITLE
Closes the participant for the workaround of cb98fee.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/base/AbstractBaseTest.java
+++ b/src/test/java/org/jitsi/meet/test/base/AbstractBaseTest.java
@@ -350,6 +350,16 @@ public abstract class AbstractBaseTest<P extends Participant>
     }
 
     /**
+     * Closes a participant's session/driver.
+     *
+     * @param participant the participant to close.
+     */
+    public void closeParticipant(P participant)
+    {
+        this.participants.closeParticipant(participant);
+    }
+
+    /**
      * Method called "AfterClass". Will clean up any dangling
      * {@link Participant}s held by the {@link ParticipantHelper}.
      */

--- a/src/test/java/org/jitsi/meet/test/base/ParticipantHelper.java
+++ b/src/test/java/org/jitsi/meet/test/base/ParticipantHelper.java
@@ -194,6 +194,18 @@ public abstract class ParticipantHelper<P extends Participant>
     }
 
     /**
+     * Closes a participant's session/driver. No exception is thrown if close
+     * do not work for some reason.
+     *
+     * @param participant the participant to close.
+     */
+    public void closeParticipant(P participant)
+    {
+        participant.closeSafely();
+        participants.remove(participant);
+    }
+
+    /**
      * Gets the list of all participants.
      * @return a copy of the list which holds all participants.
      */

--- a/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
@@ -389,7 +389,9 @@ public class WebTestBase
             // Participant did not join, let's give it another try.
             // This workarounds a problem where we see chrome waiting on media
             // permissions screen
-            participant.hangUp();
+            // we close the driver in, case of browser stuck on grid, to move
+            // to new node
+            closeParticipant(participant);
 
             participant = joinParticipant(index, meetURL, options);
             participant.waitToJoinMUC();


### PR DESCRIPTION
Closing the participant will make sure chrome is closed/quit and we move to another grid node.