### PR TITLE
improvement: allow jitsi-meet instance URL to have a trailing slash.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/base/JitsiMeetUrl.java
+++ b/src/test/java/org/jitsi/meet/test/base/JitsiMeetUrl.java
@@ -264,7 +264,14 @@ public class JitsiMeetUrl
      */
     public void setServerUrl(String serverUrl)
     {
-        this.serverUrl = serverUrl;
+        if (serverUrl != null && serverUrl.endsWith("/"))
+        {
+            this.serverUrl = serverUrl.substring(0, serverUrl.length() -1);
+        }
+        else
+        {
+            this.serverUrl = serverUrl;
+        }
     }
 
     /**


### PR DESCRIPTION
To configure against what server these tests are executed, a URL is provided
through system properties, like this:

  mvn test -Djitsi-meet.instance.url="https://meet.example.com"

This commit prevents failures when this URL ends with a slash. In other words,
this is now also acceptable:

  mvn test -Djitsi-meet.instance.url="https://meet.example.com/"