### PR TITLE
fix(mobile): set implicit wait for variable display timings

### DIFF
--- a/src/test/java/org/jitsi/meet/test/mobile/base/MobileParticipantFactory.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/base/MobileParticipantFactory.java
@@ -24,6 +24,7 @@ import org.openqa.selenium.remote.*;
 
 import java.net.*;
 import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * Creates mobile participant.
@@ -80,6 +81,8 @@ public class MobileParticipantFactory
             = type.isAndroid()
                 ? new AndroidDriver<>(appiumUrl, capabilities)
                 : new IOSDriver<>(appiumUrl, capabilities);
+
+        driver.manage().timeouts().implicitlyWait(60, TimeUnit.SECONDS);
 
         MobileParticipant participant
             = new MobileParticipant(


### PR DESCRIPTION
~~I don't know how to run the tests locally so I'm just gonna run them here...~~

The current tests do not set an implicit wait timeout. The tests assume then that overlays and dialogs will display immediately. It could be that there is a display delay, so actions to dismiss a dialog or overlay doesn't happen at the right time and blocks further test progress.

That's the guess...