### PR TITLE
[RN] Allow calendar permission on start

### DIFF
--- a/src/test/java/org/jitsi/meet/test/mobile/MobileParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/MobileParticipant.java
@@ -246,7 +246,10 @@ public class MobileParticipant extends Participant<AppiumDriver<MobileElement>>
             maybeAcceptOverlayPermissions();
         }
 
-        // ALLOW to use camera
+        // ALLOW to use camera and the calendar
+        // Due to the async nature of Redux we don't know which permission will
+        // pop up first.
+        acceptPermissionAlert();
         acceptPermissionAlert();
 
         WelcomePageView welcomePageView = new WelcomePageView(this);


### PR DESCRIPTION
Since the calendar tab changes we now have 2 permission popups on start so we need to click allow for both.

Required by https://github.com/jitsi/jitsi-meet/pull/3095 which defaults to the Calendar tab and thus may cause the appearance of the Calendar permission prompt on startup.