### PR TITLE
feat(iOS): adds support for automatic WDA signing

### DIFF
--- a/src/test/java/org/jitsi/meet/test/mobile/base/iOSParticipantOptions.java
+++ b/src/test/java/org/jitsi/meet/test/mobile/base/iOSParticipantOptions.java
@@ -48,6 +48,30 @@ public class iOSParticipantOptions
         = _CAPS_PROP_PREFIX + "udid";
 
     /**
+     * This is the bundle ID of the Appium's WebDriver Agent. It needs to be
+     * changed through the capability in order for the automatic signing
+     * scenario to work correctly. Otherwise XCode will not allow to claim
+     * the 'com.facebook.WebDriverAgentRunner' namespace and the automatic
+     * signing will fail.
+     */
+    private static final String CAPS_UPDATED_WDA_BUNDLE_ID
+        = _CAPS_PROP_PREFIX + "updatedWDABundleId";
+
+    /**
+     * The team ID used for signing. Described in the tutorial here:
+     * https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md#basic-automatic-configuration
+     */
+    private static final String CAPS_XCODE_ORG_ID
+        = _CAPS_PROP_PREFIX + "xcodeOrgId";
+
+    /**
+     * The XCode signing ID mentioned in the tutorial:
+     * https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md#basic-automatic-configuration
+     */
+    private static final String CAPS_XCODE_SIGNING_ID
+        = _CAPS_PROP_PREFIX + "xcodeSigningId";
+
+    /**
      * Default iOS value for {@link MobileParticipantOptions#PROP_BUNDLE_ID}.
      */
     private static final String DEFAULT_BUNDLE_ID = "org.jitsi.JitsiMeet.ios";
@@ -63,6 +87,17 @@ public class iOSParticipantOptions
      * Default value for {@link #CAPS_AUTOMATION}.
      */
     private static final String DEFAULT_CAPS_AUTOMATION = "XCUITest";
+
+    /**
+     * Default value for {@link #CAPS_UPDATED_WDA_BUNDLE_ID}.
+     */
+    private static final String DEFAULT_UPDATED_WDA_BUNDLE_ID
+        = "org.jitsi.WebDriverAgentRunner";
+
+    /**
+     * Default value for {@link #CAPS_XCODE_SIGNING_ID}.
+     */
+    private static final String DEFAULT_XCODE_SIGNING_ID = "iPhone Developer";
 
     /**
      * The iOS default {@link #CAPS_PLATFORM_NAME}.
@@ -81,6 +116,9 @@ public class iOSParticipantOptions
         // FIXME must be of type boolean...
         readAndSetCapability(capabilities, CAPS_SHOW_XCODE_LOG);
         readAndSetCapability(capabilities, CAPS_UDID);
+        readAndSetCapability(capabilities, CAPS_UPDATED_WDA_BUNDLE_ID);
+        readAndSetCapability(capabilities, CAPS_XCODE_ORG_ID);
+        readAndSetCapability(capabilities, CAPS_XCODE_SIGNING_ID);
 
         return capabilities;
     }
@@ -96,6 +134,9 @@ public class iOSParticipantOptions
         defaults.setProperty(CAPS_APP, DEFAULT_CAPS_APP);
         defaults.setProperty(CAPS_AUTOMATION, DEFAULT_CAPS_AUTOMATION);
         defaults.setProperty(CAPS_PLATFORM_NAME, IOS_PLATFORM_NAME);
+        defaults.setProperty(
+            CAPS_UPDATED_WDA_BUNDLE_ID, DEFAULT_UPDATED_WDA_BUNDLE_ID);
+        defaults.setProperty(CAPS_XCODE_SIGNING_ID, DEFAULT_XCODE_SIGNING_ID);
 
         defaults.setProperty(PROP_BUNDLE_ID, DEFAULT_BUNDLE_ID);
 


### PR DESCRIPTION
Adds support for the automatic WebDriverAgent Runner's signing described here:

https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md#basic-automatic-configuration