### PR TITLE
fix(etherpad): verify etherpad can be edited before editing

### DIFF
--- a/src/test/java/org/jitsi/meet/test/EtherpadTest.java
+++ b/src/test/java/org/jitsi/meet/test/EtherpadTest.java
@@ -113,6 +113,9 @@ public class EtherpadTest
 
             String textToEnter = "SomeTestText";
 
+            // Give etherpad some time to complete loading its editor content.
+            TestUtils.waitForDisplayedElementByID(driver1, "innerdocbody", 5);
+
             driver1.findElement(By.id("innerdocbody")).sendKeys(textToEnter);
 
             TestUtils.waitMillis(2000);


### PR DESCRIPTION
There can be a delay between the etherpad inner body being
displayed and being editable.