### PR TITLE
ref(shared-video): use a wrapper on click to wait for clickability

### DIFF
--- a/src/test/java/org/jitsi/meet/test/SharedVideoTest.java
+++ b/src/test/java/org/jitsi/meet/test/SharedVideoTest.java
@@ -116,9 +116,9 @@ public class SharedVideoTest
 
         currentVideoId = expectedId;
 
-        driver1.findElement(
-            By.name("jqi_state0_buttonspandatai18ndialogShareSharespan"))
-            .click();
+        TestUtils.click(
+            driver1,
+            By.name("jqi_state0_buttonspandatai18ndialogShareSharespan"));
 
         // give time for the internal frame to load and attach to the page.
         TestUtils.waitMillis(2000);
@@ -360,9 +360,11 @@ public class SharedVideoTest
     @Test(dependsOnMethods = { "switchVideoTest" })
     public void backToSharedVideoTest()
     {
-        getParticipant2().getDriver()
-            .findElement(By.id("sharedVideoContainer"))
-            .click();
+        TestUtils.click(
+            getParticipant2().getDriver(),
+            By.id("sharedVideoContainer")
+        );
+
         TestUtils.waitMillis(1000);
 
         assertTrue(
@@ -384,16 +386,10 @@ public class SharedVideoTest
 
         WebDriver driver1 = getParticipant1().getDriver();
 
-        TestUtils.waitForElementByXPath(
-            driver1,
-            "//button[@name="
-                + "'jqi_state0_buttonspandatai18ndialogCancelCancelspan']",
-            5);
-
         // let's cancel
-        driver1.findElement(
-            By.name("jqi_state0_buttonspandatai18ndialogCancelCancelspan"))
-            .click();
+        TestUtils.click(
+            driver1,
+            By.name("jqi_state0_buttonspandatai18ndialogCancelCancelspan"));
 
         // video should be visible on both sides
         WebDriver driver2 = getParticipant2().getDriver();
@@ -406,15 +402,9 @@ public class SharedVideoTest
 
         getParticipant1().getToolbar().clickSharedVideoButton();
 
-        // now lets stop sharing
-        TestUtils.waitForElementByXPath(
+        TestUtils.click(
             driver1,
-            "//button[@name="
-                + "'jqi_state0_buttonspandatai18ndialogRemoveRemovespan']",
-            5);
-        driver1.findElement(
-            By.name("jqi_state0_buttonspandatai18ndialogRemoveRemovespan"))
-            .click();
+            By.name("jqi_state0_buttonspandatai18ndialogRemoveRemovespan"));
 
         try
         {

--- a/src/test/java/org/jitsi/meet/test/util/TestUtils.java
+++ b/src/test/java/org/jitsi/meet/test/util/TestUtils.java
@@ -65,6 +65,23 @@ public class TestUtils
     }
 
     /**
+     * Click an element on the page by first checking for visibility and then
+     * checking for clickability.
+     *
+     * @param driver the {@code WebDriver}.
+     * @param by the search query for the element
+     */
+    public static void click(WebDriver driver, final By by)
+    {
+        waitForElementBy(driver, by, 10);
+        WebDriverWait wait = new WebDriverWait(driver, 10);
+        WebElement element = wait.until(
+            ExpectedConditions.elementToBeClickable(by));
+
+        element.click();
+    }
+
+    /**
      * Injects JS script into given <tt>participant</tt> <tt>WebDriver</tt>.
      * @param driver the <tt>WebDriver</tt> where the script will be
      * injected.


### PR DESCRIPTION
Often times tests will fail because a menu button is attempted
to be clicked before it is visible or clickable. Create a method
that encapsulates clicking with checks for clickability.