### PR TITLE
fix(lock-room): wait for password submit to be clickable

### DIFF
--- a/src/test/java/org/jitsi/meet/test/LockRoomTest.java
+++ b/src/test/java/org/jitsi/meet/test/LockRoomTest.java
@@ -263,6 +263,7 @@ public class LockRoomTest
 
         driver.findElement(
             By.xpath("//input[@name='lockKey']")).sendKeys(password);
-        driver.findElement(By.id("modal-dialog-ok-button")).click();
+
+        TestUtils.click(driver, By.id("modal-dialog-ok-button"));
     }
 }

--- a/src/test/java/org/jitsi/meet/test/LockRoomTest.java
+++ b/src/test/java/org/jitsi/meet/test/LockRoomTest.java
@@ -261,8 +261,11 @@ public class LockRoomTest
             By.xpath("//input[@name='lockKey']"),
             5);
 
-        driver.findElement(
-            By.xpath("//input[@name='lockKey']")).sendKeys(password);
+        WebElement passwordInput = driver.findElement(
+            By.xpath("//input[@name='lockKey']"));
+
+        passwordInput.clear();
+        passwordInput.sendKeys(password);
 
         TestUtils.click(driver, By.id("modal-dialog-ok-button"));
     }


### PR DESCRIPTION
enterParticipantInLockedRoom is being flaky right now.
Screenshots show the password input is not cleared after
attempting to submit a known bad password, indicating
maybe the known password was never submitted.