### PR TITLE
Waits for the remote participant to join.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/DialInAudioTest.java
+++ b/src/test/java/org/jitsi/meet/test/DialInAudioTest.java
@@ -184,6 +184,8 @@ public class DialInAudioTest
 
         WebParticipant participant = getParticipant1();
 
+        participant.waitForParticipants(1);
+
         participant.waitForIceConnected();
         participant.waitForRemoteStreams(1);
         participant.waitForSendReceiveData();

--- a/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
@@ -392,6 +392,20 @@ public class WebParticipant extends Participant<WebDriver>
     }
 
     /**
+     * Waits for number of participants.
+     * @param n number of participants to wait for.
+     */
+    public void waitForParticipants(int n)
+    {
+        waitForCondition(
+            () -> (Boolean) executeScript(
+                "return APP.conference"
+                    + ".listMembers().length >= " + n + ";"),
+                15,
+                "waitForParticipants:" + n);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override


### PR DESCRIPTION
If that fail we can evaluate test results and differentiate failures, did it failed cause participant didn't join or something went wrong after that.