### PR TITLE
fix(shared-video): stop returning unused objects when running js

### DIFF
--- a/src/test/java/org/jitsi/meet/test/SharedVideoTest.java
+++ b/src/test/java/org/jitsi/meet/test/SharedVideoTest.java
@@ -303,7 +303,7 @@ public class SharedVideoTest
 
         participant1.executeScript(
             JS_GET_SHARED_VIDEO_CONTAINER
-                + "return c.player.setVolume(" + volumeToSet + ");");
+                + "c.player.setVolume(" + volumeToSet + ");");
 
         // now check for volume on both sides
         String checkVolumeScript
@@ -329,7 +329,7 @@ public class SharedVideoTest
         WebParticipant participant1 = getParticipant1();
         participant1.executeScript(
             JS_GET_SHARED_VIDEO_CONTAINER
-                + "return c.player.mute();");
+                + "c.player.mute();");
         // now check for volume on both sides
         TestUtils.waitForBoolean(
             participant1.getDriver(),


### PR DESCRIPTION
This is triggering stale element exceptions right now.