### PR TITLE
Fix for Peer2Peer check

### DIFF
--- a/src/test/java/org/jitsi/meet/test/util/MeetUtils.java
+++ b/src/test/java/org/jitsi/meet/test/util/MeetUtils.java
@@ -36,7 +36,7 @@ public class MeetUtils
      * is in state 'connected'.
      */
     public static final String ICE_CONNECTED_CHECK_SCRIPT =
-        "return APP.conference.getConnectionState() === 'connected';";
+        "return APP.conference.getP2PConnectionState() === 'connected';";
 
     public static final String START_P2P_SCRIPT =
         "APP.conference._startP2P();";


### PR DESCRIPTION
Changed APP.conference.getConnectionState() to APP.conference.getP2PConnectionState() to fix Peer2Peer check.