### PR TITLE
fix #280

### DIFF
--- a/src/test/java/org/jitsi/meet/test/web/WebParticipantFactory.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipantFactory.java
@@ -208,7 +208,7 @@ public class WebParticipantFactory
             final ChromeOptions ops = new ChromeOptions();
             // Force chrome to use English instead of system language.
             // At least work at version 83.0.4103.61 on win 10
-            ops.addArguments("--lang=en");
+            ops.addArguments("lang=en");
             ops.addArguments("allow-insecure-localhost");
             ops.addArguments("use-fake-ui-for-media-stream");
             ops.addArguments("use-fake-device-for-media-stream");

--- a/src/test/java/org/jitsi/meet/test/web/WebParticipantFactory.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipantFactory.java
@@ -133,6 +133,9 @@ public class WebParticipantFactory
             }
 
             FirefoxProfile profile = new FirefoxProfile();
+            // Force firefox to use English instead of system language.
+            // Not test because of having not firefox installed.
+            profile.setPreference("intl.accept_languages","en");
             profile.setPreference("media.navigator.permission.disabled", true);
             // Enables tcp in firefox, disabled by default in 44
             profile.setPreference("media.peerconnection.ice.tcp", true);
@@ -203,6 +206,9 @@ public class WebParticipantFactory
             logPrefs.enable(LogType.BROWSER, Level.ALL);
 
             final ChromeOptions ops = new ChromeOptions();
+            // Force chrome to use English instead of system language.
+            // At least work at version 83.0.4103.61 on win 10
+            ops.addArguments("--lang=en");
             ops.addArguments("allow-insecure-localhost");
             ops.addArguments("use-fake-ui-for-media-stream");
             ops.addArguments("use-fake-device-for-media-stream");


### PR DESCRIPTION
fix #280 
Force chrome and firefox web driver use English instead of system language.
The code for chrome has test on my computer. The chrome version is 83.0.4103.61. The os system is win 10.