### PR TITLE
support port which not default to 443

### DIFF
--- a/src/test/java/org/jitsi/meet/test/IFrameAPITest.java
+++ b/src/test/java/org/jitsi/meet/test/IFrameAPITest.java
@@ -63,7 +63,7 @@ public class IFrameAPITest
         String domain;
         try
         {
-            domain = iFrameUrl.getHost();
+            domain = iFrameUrl.getHostWithPort();
         }
         catch (MalformedURLException e)
         {

--- a/src/test/java/org/jitsi/meet/test/RestTests.java
+++ b/src/test/java/org/jitsi/meet/test/RestTests.java
@@ -53,7 +53,7 @@ public class RestTests
     public void testRestAPI()
         throws MalformedURLException
     {
-        serverAddress = getJitsiMeetUrl().getHost();
+        serverAddress = getJitsiMeetUrl().getHostWithPort();
 
         checkJicofoHealth();
         checkJVBHealth();

--- a/src/test/java/org/jitsi/meet/test/base/JitsiMeetUrl.java
+++ b/src/test/java/org/jitsi/meet/test/base/JitsiMeetUrl.java
@@ -222,6 +222,27 @@ public class JitsiMeetUrl
     }
 
     /**
+     * @return a port part of the URL returned by {@link #toUrl()}.
+     * @throws MalformedURLException the same as in {@link #toUrl()}.
+     */
+    public int getPort()
+        throws MalformedURLException
+    {
+        return toUrl().getPort();
+    }
+
+    public String getHostWithPort()
+        throws MalformedURLException
+    {
+        int port = getPort();
+        if (port != 443) {
+            return getHost() + ":" + port;
+        } else {
+            return getHost();
+        }
+    }
+
+    /**
      * @return obtains {@link #roomName} part of the conference URL.
      */
     public String getRoomName()


### PR DESCRIPTION
IFrameAPITest failed because the wrong port. This pull request make test work on the host with a port other than 443, such as 8080.