### PR TITLE
fix: Adds a wait after opening security dialog on setting password.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/pageobjects/web/SecurityDialog.java
+++ b/src/test/java/org/jitsi/meet/test/pageobjects/web/SecurityDialog.java
@@ -65,6 +65,10 @@ public class SecurityDialog
 
         open();
 
+        // we see failures where clicking the password link does not propagate
+        // and does not show the password input field. Adding a wait trying to fix this
+        TestUtils.waitMillis(1000);
+
         WebElement addPasswordLink = driver.findElement(By.className(ADD_PASSWORD_LINK));
 
         new WebDriverWait(driver, 5).until(ExpectedConditions.elementToBeClickable(addPasswordLink));


### PR DESCRIPTION
Trying to fix a failure we see from time to time in the tests.