### PR TITLE
Skips prejoin test by default.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/PreJoinTest.java
+++ b/src/test/java/org/jitsi/meet/test/PreJoinTest.java
@@ -95,4 +95,10 @@ public class PreJoinTest
                 return classes.contains("disabled");
             });
     }
+
+    @Override
+    public boolean skipTestByDefault()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
We are seeing random failures for join button being not disabled.
The response of the disco-info does not contain the required display name field.