### PR TITLE
fix: Fixes another StaleElementReferenceException in lobby tests.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/LobbyTest.java
+++ b/src/test/java/org/jitsi/meet/test/LobbyTest.java
@@ -273,17 +273,12 @@ public class LobbyTest
     @Test(dependsOnMethods = {"testEnteringInLobbyAndApprove"})
     public void testLobbyUserLeaves()
     {
-        KnockingParticipantList.Participant knockingParticipant = enterLobby(getParticipant1(), false);
+        enterLobby(getParticipant1(), false);
 
         getParticipant3().hangUp();
 
-        // check that moderator (participant 1) no longer seers notification about participant in lobby
-        WebParticipant participant1 = getParticipant1();
-        KnockingParticipantList knockingParticipants
-            = participant1.getKnockingParticipantList();
-        boolean lobbyParticipantPresent = knockingParticipants.getParticipants().stream()
-            .anyMatch(p -> p.getName().equals(knockingParticipant.getName()));
-        assertFalse(lobbyParticipantPresent,
+        // check that moderator (participant 1) no longer sees notification about participant in lobby
+        assertTrue(getParticipant1().getKnockingParticipantList().waitForHideOfKnockingParticipants(),
             "Moderator should not see participant in knocking participants list after that participant leaves Lobby.");
     }
 

--- a/src/test/java/org/jitsi/meet/test/pageobjects/web/KnockingParticipantList.java
+++ b/src/test/java/org/jitsi/meet/test/pageobjects/web/KnockingParticipantList.java
@@ -104,6 +104,25 @@ public class KnockingParticipantList
     }
 
     /**
+     * Will wait 3 seconds for the knocking participants to disappear and return true or will return false.
+     * @return <tt>true</tt> if the knocking participants list was not displayed.
+     */
+    public boolean waitForHideOfKnockingParticipants()
+    {
+        try
+        {
+            TestUtils.waitForNotDisplayedElementByID(participant.getDriver(), KNOCKING_PARTICIPANT_LIST_ID, 3);
+
+            return true;
+        }
+        catch(TimeoutException ex)
+        {
+            return false;
+        }
+    }
+
+
+    /**
      * Presentation for the participants in the knocking participants list.
      */
     public class Participant


### PR DESCRIPTION
When participant leaves we can be checking the dialog in the moment it is about to hide.
org.openqa.selenium.StaleElementReferenceException: stale element reference: element is not attached to the page document
....
org.openqa.selenium.remote.RemoteWebElement.findElementById(RemoteWebElement.java:221)
  org.openqa.selenium.By$ById.findElement(By.java:188)
  org.openqa.selenium.remote.RemoteWebElement.findElement(RemoteWebElement.java:181)
  org.jitsi.meet.test.pageobjects.web.KnockingParticipantList.lambda$getParticipants$0(KnockingParticipantList.java:94)
  java.util.ArrayList.forEach(ArrayList.java:1257)
  org.jitsi.meet.test.pageobjects.web.KnockingParticipantList.getParticipants(KnockingParticipantList.java:88)
  org.jitsi.meet.test.LobbyTest.testLobbyUserLeaves(LobbyTest.java:284)
  ...