### PR TITLE
fix: Add SLF4J logger implementation dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,11 @@
             <version>3.0</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version> 1.7.30</version> 
+        </dependency>
     </dependencies>
 
     <!-- Here we list all properties that we currently support in both


### PR DESCRIPTION
When I was trying to run `./scripts/malleus.sh` with Chrome driver I got the following error:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

Adding the dependency fixes the issue and logs get printed.