### PR TITLE
Run multiple Malleus endpoints per Selenium node

### DIFF
--- a/scripts/malleus.sh
+++ b/scripts/malleus.sh
@@ -49,11 +49,11 @@ case $1 in
       AUDIO_SENDERS=$PARTICIPANTS
     fi
 
-    if [ -z "$SENDERS" ]; then
+    if [ -z "$SENDERS_PER_NODE" ]; then
       SENDERS_PER_NODE=1
     fi
 
-    if [ -z "$AUDIO_SENDERS" ]; then
+    if [ -z "$RECEIVERS_PER_NODE" ]; then
       RECEIVERS_PER_NODE=1
     fi
 

--- a/scripts/malleus.sh
+++ b/scripts/malleus.sh
@@ -11,6 +11,8 @@ case $1 in
         --participants) PARTICIPANTS=$optvalue;;
         --senders) SENDERS=$optvalue;;
         --audio-senders) AUDIO_SENDERS=$optvalue;;
+        --senders-per-node) SENDERS_PER_NODE=$optvalue;;
+        --receivers-per-node) RECEIVERS_PER_NODE=$optvalue;;
         --duration) DURATION=$optvalue;;
         --room-name-prefix) ROOM_NAME_PREFIX=$optvalue;;
         --hub-url) HUB_URL=$optvalue;;
@@ -37,6 +39,22 @@ case $1 in
 
     if [ -z "$AUDIO_SENDERS" ]; then
       AUDIO_SENDERS=$PARTICIPANTS
+    fi
+
+    if [ -z "$SENDERS" ]; then
+      SENDERS=$PARTICIPANTS
+    fi
+
+    if [ -z "$AUDIO_SENDERS" ]; then
+      AUDIO_SENDERS=$PARTICIPANTS
+    fi
+
+    if [ -z "$SENDERS" ]; then
+      SENDERS_PER_NODE=1
+    fi
+
+    if [ -z "$AUDIO_SENDERS" ]; then
+      RECEIVERS_PER_NODE=1
     fi
 
     if [ -z "$DURATION" ]; then
@@ -88,6 +106,8 @@ mvn \
 -Dorg.jitsi.malleus.participants=$PARTICIPANTS \
 -Dorg.jitsi.malleus.senders=$SENDERS \
 -Dorg.jitsi.malleus.audio_senders=$AUDIO_SENDERS \
+-Dorg.jitsi.malleus.senders_per_node=$SENDERS_PER_NODE \
+-Dorg.jitsi.malleus.receivers_per_node=$RECEIVERS_PER_NODE \
 -Dorg.jitsi.malleus.duration=$DURATION \
 -Dorg.jitsi.malleus.room_name_prefix=$ROOM_NAME_PREFIX \
 -Dorg.jitsi.malleus.regions=$REGIONS \

--- a/src/test/java/org/jitsi/meet/test/JibriTest.java
+++ b/src/test/java/org/jitsi/meet/test/JibriTest.java
@@ -310,7 +310,7 @@ public class JibriTest
         WebDriver driver = participant.getDriver();
 
         driver.get(url);
-        MeetUtils.waitForPageToLoad(driver);
+        MeetUtils.waitForPageToLoad(driver, null);
 
         participant.executeScript(
                 "document.title='" + participant.getName() + "'");

--- a/src/test/java/org/jitsi/meet/test/MalleusJitsificus.java
+++ b/src/test/java/org/jitsi/meet/test/MalleusJitsificus.java
@@ -64,19 +64,19 @@ public class MalleusJitsificus
             return new Object[0][0];
         }
 
-        int numConferences = Integer.valueOf(System.getProperty(CONFERENCES_PNAME));
-        int numParticipants = Integer.valueOf(System.getProperty(PARTICIPANTS_PNAME));
+        int numConferences = Integer.parseInt(System.getProperty(CONFERENCES_PNAME));
+        int numParticipants = Integer.parseInt(System.getProperty(PARTICIPANTS_PNAME));
         String numSendersStr = System.getProperty(SENDERS_PNAME);
         int numSenders = numSendersStr == null
             ? numParticipants
-            : Integer.valueOf(numSendersStr);
+            : Integer.parseInt(numSendersStr);
 
         String numAudioSendersStr = System.getProperty(AUDIO_SENDERS_PNAME);
         int numAudioSenders = numAudioSendersStr == null
                 ? numParticipants
-                : Integer.valueOf(numAudioSendersStr);
+                : Integer.parseInt(numAudioSendersStr);
 
-        int timeoutMs = 1000 * Integer.valueOf(System.getProperty(DURATION_PNAME));
+        int timeoutMs = 1000 * Integer.parseInt(System.getProperty(DURATION_PNAME));
 
         String[] regions = null;
         String regionsStr = System.getProperty(REGIONS_PNAME);

--- a/src/test/java/org/jitsi/meet/test/base/Participant.java
+++ b/src/test/java/org/jitsi/meet/test/base/Participant.java
@@ -73,6 +73,12 @@ public abstract class Participant<T extends WebDriver>
     private String joinedRoomName = null;
 
     /**
+     * Whether this is a "secondary" participant, i.e. reusing another
+     * participant's driver.
+     */
+    private final boolean secondary;
+
+    /**
      * Executor that is responsible for keeping the participant session alive.
      */
     private ScheduledExecutorService executor
@@ -102,6 +108,21 @@ public abstract class Participant<T extends WebDriver>
         this.driver = Objects.requireNonNull(driver, "driver");
         this.type = Objects.requireNonNull(type, "type");
         this.defaultConfig = defaultConfig;
+        this.secondary = false;
+    }
+
+    /**
+     * Constructs a secondary Participant based on another one.
+     */
+    public Participant(
+        String name,
+        Participant<T> other)
+    {
+        this.name = name;
+        this.driver = other.driver;
+        this.type = other.type;
+        this.defaultConfig = other.defaultConfig;
+        this.secondary = true;
     }
 
     /**
@@ -110,7 +131,10 @@ public abstract class Participant<T extends WebDriver>
      */
     public void initialize()
     {
-        startKeepAliveExecution();
+        if (!secondary)
+        {
+            startKeepAliveExecution();
+        }
     }
 
     /**
@@ -197,6 +221,11 @@ public abstract class Participant<T extends WebDriver>
      */
     public void close()
     {
+        if (secondary)
+        {
+            return;
+        }
+
         TestUtils.print("Closing " + name);
 
         cancelKeepAlive();

--- a/src/test/java/org/jitsi/meet/test/base/Participant.java
+++ b/src/test/java/org/jitsi/meet/test/base/Participant.java
@@ -160,7 +160,7 @@ public abstract class Participant<T extends WebDriver>
 
         meetURL.appendConfig(defaultConfig, false /* do not override */);
 
-        TestUtils.print(getName() + " is opening URL: " + meetURL);
+        TestUtils.print(getName() + (secondary ? " (secondary)" : "") + " is opening URL: " + meetURL);
 
         // not hungup, so not joining
         // FIXME this should also check for room parameters, config etc.

--- a/src/test/java/org/jitsi/meet/test/base/ParticipantHelper.java
+++ b/src/test/java/org/jitsi/meet/test/base/ParticipantHelper.java
@@ -50,6 +50,11 @@ public abstract class ParticipantHelper<P extends Participant>
     private final List<P> participants;
 
     /**
+     * The current list of "primary" participants, that own their driver connections.
+     */
+    private final List<P> primaryParticipants;
+
+    /**
      * Default.
      *
      * @param config - The config which will be used as a properties source for
@@ -59,6 +64,7 @@ public abstract class ParticipantHelper<P extends Participant>
     {
         this.config = Objects.requireNonNull(config, "config");
         this.participants = new CopyOnWriteArrayList<>();
+        this.primaryParticipants = new CopyOnWriteArrayList<>();
         this.participantFactory = null;
     }
 
@@ -148,12 +154,22 @@ public abstract class ParticipantHelper<P extends Participant>
         P participant = participantFactory.createParticipant(targetOptions);
 
         participants.add(participant);
+        primaryParticipants.add(participant);
 
         TestUtils.print(
                 "Started " + participant.getType()
                     + " driver for prefix: " + configPrefix);
 
         return participant;
+    }
+
+    /**
+     * Registers a secondary participant.
+     *
+     * */
+    public void registerSecondaryParticipant(P participant)
+    {
+        participants.add(participant);
     }
 
     /**
@@ -171,7 +187,7 @@ public abstract class ParticipantHelper<P extends Participant>
      */
     public void cleanup()
     {
-        participants.stream().forEach(Participant::closeSafely);
+        primaryParticipants.stream().forEach(Participant::closeSafely);
         participants.clear();
     }
 
@@ -181,7 +197,7 @@ public abstract class ParticipantHelper<P extends Participant>
      */
     public void hangUpByIndex(int index)
     {
-        Participant participant = get(index);
+        P participant = get(index);
         if (participant != null)
             participant.hangUp();
     }

--- a/src/test/java/org/jitsi/meet/test/base/ParticipantHelper.java
+++ b/src/test/java/org/jitsi/meet/test/base/ParticipantHelper.java
@@ -165,11 +165,18 @@ public abstract class ParticipantHelper<P extends Participant>
 
     /**
      * Registers a secondary participant.
-     *
-     * */
+     */
     public void registerSecondaryParticipant(P participant)
     {
         participants.add(participant);
+    }
+
+    /**
+     * Unregisters a secondary participant.
+     */
+    public void unregisterSecondaryParticipant(P participant)
+    {
+        participants.remove(participant);
     }
 
     /**

--- a/src/test/java/org/jitsi/meet/test/util/MeetUtils.java
+++ b/src/test/java/org/jitsi/meet/test/util/MeetUtils.java
@@ -236,8 +236,10 @@ public class MeetUtils
     /**
      * Waits for the page to be loaded before continuing with the operations.
      * @param driver the webdriver that just loaded a page
+     * @param windowHandle
      */
-    public static void waitForPageToLoad(WebDriver driver)
+    public static void waitForPageToLoad(WebDriver driver,
+        String windowHandle)
     {
         String checkPageLoadScript = "" +
             "var state = ''; " +
@@ -249,16 +251,23 @@ public class MeetUtils
         try
         {
             wait.until(driverInstance -> {
-                try
+                synchronized (driverInstance)
                 {
-                    return ((JavascriptExecutor) driverInstance)
-                        .executeScript(checkPageLoadScript)
-                        .equals("complete");
-                }
-                catch (Exception e)
-                {
-                    e.printStackTrace();
-                    return false;
+                    try
+                    {
+                        if (windowHandle != null)
+                        {
+                            driverInstance.switchTo().window(windowHandle);
+                        }
+                        return ((JavascriptExecutor) driverInstance)
+                            .executeScript(checkPageLoadScript)
+                            .equals("complete");
+                    }
+                    catch (Exception e)
+                    {
+                        e.printStackTrace();
+                        return false;
+                    }
                 }
             });
         }


### PR DESCRIPTION
This adds support for running Malleus load testing with multiple endpoints per selenium node, so larger tests can be run without needing comparably larger grids.

Note this is a WIP: there seem to still be some synchronization issues where Selenium is pointing at the wrong browser window (characterized by JavaScript errors).  Insights are welcome...