### PR TITLE
Set pcStatsInterval on Malleus tests.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/MalleusJitsificus.java
+++ b/src/test/java/org/jitsi/meet/test/MalleusJitsificus.java
@@ -124,6 +124,7 @@ public class MalleusJitsificus
                 .appendConfig("config.p2p.useStunTurn=true")
                 .appendConfig("config.disable1On1Mode=false")
                 .appendConfig("config.testing.noAutoPlayVideo=true")
+                .appendConfig("config.pcStatsInterval=10000")
 
                 .appendConfig("config.p2p.enabled=" + (enableP2p ? "true" : "false"));
             ret[i] = new Object[] { url, numParticipants, timeoutMs, numSenders, numAudioSenders, regions};


### PR DESCRIPTION
This overrides the jitsi-meet-torture interval setting of 1500 back to the lib-jitsi-meet default setting of 10000.

I'd rather leave it blank entirely, and thus use the site's default value, but unfortunately the current structure of the jitsi-meet-torture code doesn't allow that.