### PR TITLE
Change test to support new atlaskit version of checkbox

### DIFF
--- a/src/test/java/org/jitsi/meet/test/pageobjects/web/SettingsDialog.java
+++ b/src/test/java/org/jitsi/meet/test/pageobjects/web/SettingsDialog.java
@@ -212,7 +212,7 @@ public class SettingsDialog
 
         if (check != isChecked)
         {
-            checkbox.click();
+            ((JavascriptExecutor)driver).executeScript("arguments[0].click();", checkbox);
         }
     }
 }


### PR DESCRIPTION
This change is required to support the new version of atlaskit checkbox component in jitsi-meet. The new compontent uses a `appearance: none` css style wich causes `WebElement.click()` to fail with `ElementNotInteractableException` because it is not visible to Selenium. The checkbox is keyboard and mouse accessible in the browser though. The PR is a requirement for https://github.com/jitsi/jitsi-meet/pull/8423 to land.