### PR TITLE
fix(StartMutedTest): Do not check for send media on p2 after join.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/StartMutedTest.java
+++ b/src/test/java/org/jitsi/meet/test/StartMutedTest.java
@@ -58,7 +58,12 @@ public class StartMutedTest
         settingsDialog.setStartVideoMuted(true);
         settingsDialog.submit();
 
-        ensureTwoParticipants();
+        ensureOneParticipant();
+
+        WebParticipant participant2 = joinSecondParticipant();
+        participant2.waitToJoinMUC();
+        participant2.waitForIceConnected();
+        participant2.waitForSendReceiveData(false, true);
 
         // On the PR testing machine it seems that some audio is leaking before
         // we mute. The audio is muted when 'session-initiate' is received, but
@@ -82,10 +87,12 @@ public class StartMutedTest
                 "config.debugAudioLevels=true&" +
                 "config.startVideoMuted=1"));
 
-        ensureTwoParticipants();
+        WebParticipant participant2 = joinSecondParticipant();
+        participant2.waitToJoinMUC();
+        participant2.waitForIceConnected();
+        participant2.waitForSendReceiveData(false, true);
 
         WebParticipant participant1 = getParticipant1();
-        WebParticipant participant2 = getParticipant2();
 
         final WebDriver driver2 = participant2.getDriver();
         consolePrint(participant1,


### PR DESCRIPTION
This PR - https://github.com/jitsi/jitsi-meet/pull/8716 changes the behavior of startAudioMuted/startVideoMuted settings. Since tracks are not added to the peerconnection, no media will be sent by participant2 when it joins the call. Earlier, because the tracks were muted after join, audio packets (silence) were sent out by participant2.