### PR TITLE
fix(DesktopSharingTest): Do not check for send media on p2.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/DesktopSharingTest.java
+++ b/src/test/java/org/jitsi/meet/test/DesktopSharingTest.java
@@ -193,7 +193,6 @@ public class DesktopSharingTest
         WebParticipant participant2 = joinSecondParticipant(meetUrl2);
         participant2.waitToJoinMUC();
         participant2.waitForIceConnected();
-        participant2.waitForSendReceiveData(true, false);
 
         WebParticipant participant3 = joinThirdParticipant();
         participant3.waitToJoinMUC();


### PR DESCRIPTION
Now that audio track is not added on startWithAudioMuted, participant2 (that starts audio muted) will not be sending any media when participant1 is in audio-only mode.