### PR TITLE
Skip DesktopSharingTest.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/DesktopSharingTest.java
+++ b/src/test/java/org/jitsi/meet/test/DesktopSharingTest.java
@@ -130,6 +130,12 @@ public class DesktopSharingTest
             5);
     }
 
+    @Override
+    public boolean skipTestByDefault()
+    {
+        return true;
+    }
+
     /**
      * A case where do non dominant speaker is sharing screen for a participant in low bandwidth mode
      * where only a screen share can be received. A bug fixed in jvb 0c5dd91b where the video was not received.


### PR DESCRIPTION
Skipping the test until we are able to troubleshoot the test failures.