### PR TITLE
Update WebParticipant.java

### DIFF
--- a/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
@@ -51,7 +51,7 @@ public class WebParticipant extends Participant<WebDriver>
             + "&config.alwaysVisibleToolbar=true"
             + "&config.p2p.enabled=false"
             + "&config.p2p.useStunTurn=false"
-            + "&config.pcStatsInterval=1500"
+            + "&config.pcStatsInterval=10000"
             + "&config.prejoinPageEnabled=false"
             + "&config.gatherStats=true"
             + "&config.disable1On1Mode=true"


### PR DESCRIPTION
in jitsi config.js file, the default value of  pcStatsInterval is 10000, so current value 1500 should be changed into 10000.

--- config.js--- 
  // The interval at which PeerConnection.getStats() is called. Defaults to 10000, 
    // pcStatsInterval: 10000,