### PR TITLE
Fix: Re-enable DesktopSharingTest.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/DesktopSharingTest.java
+++ b/src/test/java/org/jitsi/meet/test/DesktopSharingTest.java
@@ -130,12 +130,6 @@ public class DesktopSharingTest
             5);
     }
 
-    @Override
-    public boolean skipTestByDefault()
-    {
-        return true;
-    }
-
     /**
      * A case where do non dominant speaker is sharing screen for a participant in low bandwidth mode
      * where only a screen share can be received. A bug fixed in jvb 0c5dd91b where the video was not received.


### PR DESCRIPTION
They were failing because of a lastN issue that has now been fixed in the bridge - https://github.com/jitsi/jitsi-videobridge/commit/f540df412cdc12b7f34e7eae16099c0e2c8ec413.