### PR TITLE
fix: Directly select audio-only mode.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/AudioOnlyTest.java
+++ b/src/test/java/org/jitsi/meet/test/AudioOnlyTest.java
@@ -172,8 +172,9 @@ public class AudioOnlyTest
             TestUtils.waitForCondition(
                 participantDriver,
                 2,
-                (ExpectedCondition<Boolean>) d -> Integer.parseInt(videoQualitySlider.getAttribute("value"))
-                    == audioOnlySliderValue);
+                (ExpectedCondition<Boolean>) d -> Integer.parseInt(
+                    d.findElement(By.className(VIDEO_QUALITY_SLIDER_CLASS)).getAttribute("value"))
+                        == audioOnlySliderValue);
         }
         else
         {

--- a/src/test/java/org/jitsi/meet/test/AudioOnlyTest.java
+++ b/src/test/java/org/jitsi/meet/test/AudioOnlyTest.java
@@ -21,6 +21,7 @@ import org.jitsi.meet.test.web.*;
 
 import org.openqa.selenium.*;
 import org.openqa.selenium.interactions.*;
+import org.openqa.selenium.support.ui.*;
 import org.testng.annotations.*;
 
 /**
@@ -156,13 +157,23 @@ public class AudioOnlyTest
 
         if (audioOnly)
         {
+            // audio only is the first option (the min)
+            // give time for the opening of the dialog, we see that the following click does not succeed on FF
+            TestUtils.waitMillis(500);
+
             // a workaround to directly go to audio only mode without going through the rest of the settings
             new Actions(participantDriver)
-                .moveByOffset(videoQualitySlider.getLocation().getX(), videoQualitySlider.getLocation().getY())
+                .moveByOffset(videoQualitySlider.getLocation().getX() + 3, videoQualitySlider.getLocation().getY() + 3)
                 .build()
                 .perform();
 
             new Actions(participantDriver).click().perform();
+
+            TestUtils.waitForCondition(
+                participantDriver,
+                2,
+                (ExpectedCondition<Boolean>) d -> Integer.parseInt(videoQualitySlider.getAttribute("value"))
+                    == audioOnlySliderValue);
         }
         else
         {

--- a/src/test/java/org/jitsi/meet/test/AudioOnlyTest.java
+++ b/src/test/java/org/jitsi/meet/test/AudioOnlyTest.java
@@ -168,13 +168,6 @@ public class AudioOnlyTest
                 .perform();
 
             new Actions(participantDriver).click().perform();
-
-            TestUtils.waitForCondition(
-                participantDriver,
-                2,
-                (ExpectedCondition<Boolean>) d -> Integer.parseInt(
-                    d.findElement(By.className(VIDEO_QUALITY_SLIDER_CLASS)).getAttribute("value"))
-                        == audioOnlySliderValue);
         }
         else
         {

--- a/src/test/java/org/jitsi/meet/test/AudioOnlyTest.java
+++ b/src/test/java/org/jitsi/meet/test/AudioOnlyTest.java
@@ -20,6 +20,7 @@ import org.jitsi.meet.test.util.*;
 import org.jitsi.meet.test.web.*;
 
 import org.openqa.selenium.*;
+import org.openqa.selenium.interactions.*;
 import org.testng.annotations.*;
 
 /**
@@ -152,16 +153,27 @@ public class AudioOnlyTest
 
         int activeValue
             = Integer.parseInt(videoQualitySlider.getAttribute("value"));
-        int targetValue
-            = audioOnly ? audioOnlySliderValue : maxDefinitionSliderValue;
 
-        int distanceToTargetValue = targetValue - activeValue;
-        Keys keyDirection = distanceToTargetValue > 0 ? Keys.RIGHT : Keys.LEFT;
-
-        // Move the slider to the target value.
-        for (int i = 0; i < Math.abs(distanceToTargetValue); i++)
+        if (audioOnly)
         {
-            videoQualitySlider.sendKeys(keyDirection);
+            // a workaround to directly go to audio only mode without going through the rest of the settings
+            new Actions(participantDriver)
+                .moveByOffset(videoQualitySlider.getLocation().getX(), videoQualitySlider.getLocation().getY())
+                .build()
+                .perform();
+
+            new Actions(participantDriver).click().perform();
+        }
+        else
+        {
+            int distanceToTargetValue = maxDefinitionSliderValue - activeValue;
+            Keys keyDirection = distanceToTargetValue > 0 ? Keys.RIGHT : Keys.LEFT;
+
+            // Move the slider to the target value.
+            for (int i = 0; i < Math.abs(distanceToTargetValue); i++)
+            {
+                videoQualitySlider.sendKeys(keyDirection);
+            }
         }
 
         // Close the video quality dialog.


### PR DESCRIPTION
This fix failing test DesktopSharingTest.testAudioOnlyAndNonDominantScreenShare, so if we go through low definition we set video-quality/preferredVideoQuality to 180 which is sent as maxHeight:180 to bridge and as the screenshare is with low bandwidth the bridge start sending it after 16 seconds.