### PR TITLE
fix: Temporary bump wait time.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/DesktopSharingTest.java
+++ b/src/test/java/org/jitsi/meet/test/DesktopSharingTest.java
@@ -165,7 +165,7 @@ public class DesktopSharingTest
         // the video should be playing
         TestUtils.waitForBoolean(getParticipant1().getDriver(),
             "return JitsiMeetJS.app.testing.isLargeVideoReceived();",
-            10);
+            20);
     }
 
     /**


### PR DESCRIPTION
This is known that the slowness comes from the bridge and after we fix it there will revert this change.