### PR TITLE
fix: Directly select audio-only mode.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/DesktopSharingTest.java
+++ b/src/test/java/org/jitsi/meet/test/DesktopSharingTest.java
@@ -142,7 +142,13 @@ public class DesktopSharingTest
         hangUpAllParticipants();
 
         ensureOneParticipant();
-        AudioOnlyTest.setAudioOnly(getParticipant1(), true);
+
+        WebDriver driver1 = getParticipant1().getDriver();
+
+        // a workaround to directly set audio only mode without going through the rest of the settings in the UI
+        TestUtils.executeScript(driver1, "APP.store.dispatch({type: 'SET_AUDIO_ONLY', audioOnly: true});");
+        TestUtils.executeScript(driver1, "APP.UI.emitEvent('UI.toggle_audioonly', true);");
+
         getParticipant1().getToolbar().clickAudioMuteButton();
 
         WebParticipant participant2 = joinSecondParticipant();


### PR DESCRIPTION
This fix failing test DesktopSharingTest.testAudioOnlyAndNonDominantScreenShare, so if we go through low definition we set video-quality/preferredVideoQuality to 180 which is sent as maxHeight:180 to bridge and as the screenshare is with low bandwidth the bridge start sending it after 16 seconds.