### PR TITLE
feat: Skips failing dial-in tests on page crash.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/DialInAudioTest.java
+++ b/src/test/java/org/jitsi/meet/test/DialInAudioTest.java
@@ -301,6 +301,16 @@ public class DialInAudioTest
                 + (System.currentTimeMillis() - restAPIExecutionTS) + " ms.");
             throw e;
         }
+        catch(WebDriverException e)
+        {
+            if (e.getMessage().contains("crash"))
+            {
+                e.printStackTrace();
+                // page crashed we don't want to fail on this one
+                userJoined = false;
+                return;
+            }
+        }
 
         long joinedTS = System.currentTimeMillis();
 


### PR DESCRIPTION
00:33:49 [10] TestFailure:
00:33:49 org.openqa.selenium.WebDriverException: unknown error: session deleted because of page crash
00:33:49 from unknown error: cannot determine loading status
00:33:49 from tab crashed
00:33:49   (Session info: chrome=93.0.4577.82)
00:33:49 Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
00:33:49 System info: host: 'jenkins.jitsi.net', ip: '52.41.182.55', os.name: 'Linux', os.arch: 'amd64', os.version: '4.15.0-1025-aws', java.version: '1.8.0_265'
00:33:49 Driver info: org.openqa.selenium.remote.RemoteWebDriver
00:33:49 Capabilities {acceptInsecureCerts: false, browserName: chrome, browserVersion: 93.0.4577.82, chrome: {chromedriverVersion: 93.0.4577.63 (ff5c0da2ec0ad..., userDataDir: /tmp/.com.google.Chrome.nHmuRj}, goog:chromeOptions: {debuggerAddress: localhost:33549}, javascriptEnabled: true, networkConnectionEnabled: false, pageLoadStrategy: normal, platform: LINUX, platformName: LINUX, proxy: Proxy(), setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify, webauthn:extension:credBlob: true, webauthn:extension:largeBlob: true, webauthn:virtualAuthenticators: true, webdriver.remote.sessionid: 6498d8c9468a30b5b78e76cddd0...}
00:33:49 Session ID: 6498d8c9468a30b5b78e76cddd0e2cf7
00:33:49 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
00:33:49 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
00:33:49 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
00:33:49 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
00:33:49 	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.createException(W3CHttpResponseCodec.java:187)
00:33:49 	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:122)
00:33:49 	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:49)
00:33:49 	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:158)
00:33:49 	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
00:33:49 	at org.openqa.selenium.remote.RemoteWebDriver.executeScript(RemoteWebDriver.java:489)
00:33:49 	at org.jitsi.meet.test.web.WebParticipant.executeScript(WebParticipant.java:265)
00:33:49 	at org.jitsi.meet.test.web.WebParticipant.lambda$waitForParticipants$2(WebParticipant.java:472)
00:33:49 	at org.jitsi.meet.test.base.Participant$1.apply(Participant.java:399)
00:33:49 	at org.jitsi.meet.test.base.Participant$1.apply(Participant.java:395)
00:33:49 	at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:249)
00:33:49 	at org.jitsi.meet.test.util.TestUtils.waitForCondition(TestUtils.java:508)
00:33:49 	at org.jitsi.meet.test.base.Participant.waitForCondition(Participant.java:391)
00:33:49 	at org.jitsi.meet.test.web.WebParticipant.waitForParticipants(WebParticipant.java:471)
00:33:49 	at org.jitsi.meet.test.DialInAudioTest.waitForAudioFromDialIn(DialInAudioTest.java:296)