### PR TITLE
fix: Fixes failing lobby test and missing first participant.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/LobbyTest.java
+++ b/src/test/java/org/jitsi/meet/test/LobbyTest.java
@@ -318,6 +318,13 @@ public class LobbyTest
         assertFalse(participant3.getLobbyScreen().isLobbyRoomJoined(), "Lobby room not left");
 
         participant3.hangUp();
+
+        hangUpAllParticipants();
+
+        // waits just wait a little to be sure the conference had been destroyed
+        // we see sometimes the first participant not able to join in next test as maybe the conference is still there
+        // with lobby enabled and waiting for a minute the ghost to expire and destroy the conference
+        TestUtils.waitMillis(500);
     }
 
     /**

--- a/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
@@ -284,23 +284,9 @@ public class WebTestBase
 
         if (p == null)
         {
-            // There's an assumption that the participants are created
-            // starting from 0, 1, 2, so throw an Exception if they happen to be
-            // created in different order.
-            int size = participants.getAll().size();
-            if (index != size)
-            {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "New participant would have been inserted at different "
-                                        + "index than expected. Index: %d, size %d.",
-                                index,
-                                size));
-            }
-
             String configPrefix = "web.participant" + (index + 1);
 
-            p = participants.createParticipant(configPrefix, options);
+            p = participants.createParticipant(index, configPrefix, options);
 
             // Adds a print in the console/selenium-node logs
             // useful when checking crashes or failures in node logs


### PR DESCRIPTION
Seems like from time to time we quickly hangup one of the participants in testConferenceEndedInLobby test, and it stays in the room with lobby enabled. In that case when participant 1 in next test tries to join fails on isInMuc check as there is Lobby. We close it deciding that chrome crashed and try again. The problem was that our close is wrong and the indexes are messed up and participant2 becomes participant1 and everything starts failing :)
Fixes the close which is used only in that rare case we consider as chrome crash ... we may eventually get rid of that workaround as we no longer see chrome crashes.