### PR TITLE
Fix mute test

### DIFF
--- a/src/test/java/org/jitsi/meet/test/MuteTest.java
+++ b/src/test/java/org/jitsi/meet/test/MuteTest.java
@@ -245,15 +245,14 @@ public class MuteTest
 
         getParticipant1().getToolbar().clickVideoMuteButton();
 
-        // Wait 3 secs before adding the second participant so that the stream is set to null on the local track
-        // before the peerconnection is created as p2 joins.
-        TestUtils.waitMillis(3000);
-
         WebParticipant participant1 = getParticipant1();
         WebParticipant participant2 = joinSecondParticipant(url2);
         participant2.waitToJoinMUC();
         participant2.waitForIceConnected();
-        participant2.waitForSendReceiveData(true, true);
+        participant2.waitForSendReceiveData(true, false);
+
+        // Wait for the media to switch over to the p2p connection.
+        TestUtils.waitMillis(2000);
 
         // Check if p1 appears video muted on p2.
         participant2.getFilmstrip().assertVideoMuteIcon(participant1, true);

--- a/src/test/java/org/jitsi/meet/test/MuteTest.java
+++ b/src/test/java/org/jitsi/meet/test/MuteTest.java
@@ -251,7 +251,11 @@ public class MuteTest
 
         WebParticipant participant1 = getParticipant1();
         WebParticipant participant2 = joinSecondParticipant(url2);
+        participant2.waitToJoinMUC();
+        participant2.waitForIceConnected();
+        participant2.waitForSendReceiveData(true, true);
 
+        // Check if p1 appears video muted on p2.
         participant2.getFilmstrip().assertVideoMuteIcon(participant1, true);
 
         // Start desktop share.

--- a/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebTestBase.java
@@ -304,7 +304,7 @@ public class WebTestBase
         {
             // participant names are `web.participantN` we drop `web.`. Shorter for display in thumbs and avatar is PN.
             String displayName = p.getName().replaceAll("web\\.", "");
-            meetURL.appendConfig("userInfo.displayName=\"" + displayName + "\"", false);
+            meetURL.appendConfig("userInfo.displayName=\"" + displayName + "\"", true);
         }
 
         p.joinConference(meetURL);


### PR DESCRIPTION
fix(MuteTest): Wait for p2 to connect before starting share on p1.
fix: Always override displayName when adding a participant to the call.