### PR TITLE
feat(config) replaced interfaceConfig with config on DisplayNameTest

### DIFF
--- a/src/test/java/org/jitsi/meet/test/DisplayNameTest.java
+++ b/src/test/java/org/jitsi/meet/test/DisplayNameTest.java
@@ -134,7 +134,7 @@ public class DisplayNameTest
         WebParticipant participant2 = getParticipant2();
         String defaultDisplayName =
             (String) participant1.executeScript(
-                    "return interfaceConfig.DEFAULT_REMOTE_DISPLAY_NAME;");
+                    "return config.defaultRemoteDisplayName;");
 
         // check on first browser
         checkRemoteVideoForName(


### PR DESCRIPTION
Based on the fact that we migrated defaultRemoteDisplayName and defaultLocalDisplayName from interfaceConfig to config