### PR TITLE
fix(breakout-rooms) Start meeting with audio muted

### DIFF
--- a/src/test/java/org/jitsi/meet/test/BreakoutRoomsTest.java
+++ b/src/test/java/org/jitsi/meet/test/BreakoutRoomsTest.java
@@ -269,7 +269,9 @@ public class BreakoutRoomsTest
         // because the participants rejoin so fast, the meeting is not properly ended,
         // so the previous breakout rooms would still be there.
         // To avoid this issue we use a different meeting
-        JitsiMeetUrl url = getJitsiMeetUrl().setRoomName("random-room-name");
+        JitsiMeetUrl url = getJitsiMeetUrl()
+                .setRoomName("random-room-name")
+                .appendConfig("config.startWithAudioMuted=true");
         ensureTwoParticipants(url, url);
 
         ParticipantsPane pane = participant1.getParticipantsPane();


### PR DESCRIPTION
Added startWithAudioMuted to prevent reordering in the participants pane