### PR TITLE
fix: Run malleus.sh without any arguments

### DIFF
--- a/scripts/malleus.sh
+++ b/scripts/malleus.sh
@@ -80,6 +80,10 @@ set_defaults() {
 }
 
 case $1 in
+  "")
+    # no args provided, falling back to environment variables and default values
+    set_defaults
+    ;;
   --*)
     # new arg parsing code that includes default values for the different options.
     for arg in "$@"; do


### PR DESCRIPTION
This will allow to launch `malleus.sh` without any arguments.

Before this, `malleus.sh` would fallback to https://github.com/jitsi/jitsi-meet-torture/blob/master/scripts/malleus.sh#L130 and display `usage`.

Closes #489 