### PR TITLE
fix(stage-filmstrip) Disable stage filmstrip on some tests

### DIFF
--- a/src/test/java/org/jitsi/meet/test/AvatarTest.java
+++ b/src/test/java/org/jitsi/meet/test/AvatarTest.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.meet.test;
 
+import org.jitsi.meet.test.base.JitsiMeetUrl;
 import org.jitsi.meet.test.pageobjects.web.*;
 import org.jitsi.meet.test.util.*;
 import org.jitsi.meet.test.web.*;
@@ -126,7 +127,8 @@ public class AvatarTest
             participant2AvatarSrc);
 
         // Start the third participant
-        ensureThreeParticipants();
+        JitsiMeetUrl url = getJitsiMeetUrl().appendConfig("config.filmstrip.disableStageFilmstrip=true");
+        ensureThreeParticipants(null, null, url);
 
         // Temporary wait few seconds so the avatar to be downloaded from libravatar
         // Seems there is some delay when requesting it

--- a/src/test/java/org/jitsi/meet/test/FollowMeTest.java
+++ b/src/test/java/org/jitsi/meet/test/FollowMeTest.java
@@ -17,6 +17,7 @@ package org.jitsi.meet.test;
 
 import java.util.stream.*;
 
+import org.jitsi.meet.test.base.JitsiMeetUrl;
 import org.jitsi.meet.test.pageobjects.web.*;
 import org.jitsi.meet.test.util.*;
 import org.jitsi.meet.test.web.*;
@@ -45,7 +46,9 @@ public class FollowMeTest
     {
         super.setupClass();
 
-        ensureTwoParticipants();
+
+        JitsiMeetUrl url = getJitsiMeetUrl().appendConfig("config.filmstrip.disableStageFilmstrip=true");
+        ensureTwoParticipants(url, url);
 
         oneTimeSetUp();
     }

--- a/src/test/java/org/jitsi/meet/test/IFrameAPIGeneral.java
+++ b/src/test/java/org/jitsi/meet/test/IFrameAPIGeneral.java
@@ -40,6 +40,7 @@ public class IFrameAPIGeneral
     public void testIFrameAPI()
     {
         JitsiMeetUrl iFrameUrl = getIFrameUrl(null, null);
+        iFrameUrl.appendConfig("config.filmstrip.disableStageFilmstrip=true");
 
         ensureOneParticipant(iFrameUrl);
         WebDriver driver1 = getParticipant1().getDriver();

--- a/src/test/java/org/jitsi/meet/test/TileViewTest.java
+++ b/src/test/java/org/jitsi/meet/test/TileViewTest.java
@@ -16,6 +16,7 @@
 
 package org.jitsi.meet.test;
 
+import org.jitsi.meet.test.base.JitsiMeetUrl;
 import org.jitsi.meet.test.util.*;
 import org.jitsi.meet.test.web.*;
 import org.openqa.selenium.*;
@@ -50,7 +51,8 @@ public class TileViewTest
     {
         super.setupClass();
 
-        ensureTwoParticipants();
+        JitsiMeetUrl url = getJitsiMeetUrl().appendConfig("config.filmstrip.disableStageFilmstrip=true");
+        ensureTwoParticipants(url, url);
     }
 
     /**


### PR DESCRIPTION
Disable it on the tests that require only 1 participant on stage