### PR TITLE
fix: Fixes OutOfBoundsException in breakout tests.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/BreakoutRoomsTest.java
+++ b/src/test/java/org/jitsi/meet/test/BreakoutRoomsTest.java
@@ -161,7 +161,10 @@ public class BreakoutRoomsTest
 
         // the second participant should see no participants in the breakout room
         TestUtils.waitForCondition(participant2.getDriver(), 5, (ExpectedCondition<Boolean>) d ->
-                participant2.getBreakoutRoomsList().getRooms().get(0).getParticipantsCount() == 0);
+            {
+                List<BreakoutRoomsList.BreakoutRoom> rooms = participant2.getBreakoutRoomsList().getRooms();
+                return rooms.size() == 1 && rooms.get(0).getParticipantsCount() == 0;
+            });
     }
 
     @Test(dependsOnMethods = { "testLeaveRoom" })


### PR DESCRIPTION
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
java.util.ArrayList.rangeCheck(ArrayList.java:659)
java.util.ArrayList.get(ArrayList.java:435)
org.jitsi.meet.test.BreakoutRoomsTest.lambda$testLeaveRoom$9(BreakoutRoomsTest.java:164)
org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:249)
org.jitsi.meet.test.util.TestUtils.waitForCondition(TestUtils.java:545)
org.jitsi.meet.test.util.TestUtils.waitForCondition(TestUtils.java:559)
org.jitsi.meet.test.BreakoutRoomsTest.testLeaveRoom(BreakoutRoomsTest.java:163)