### PR TITLE
fix: Disable chrome debug logging.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/web/WebParticipantFactory.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipantFactory.java
@@ -304,8 +304,8 @@ public class WebParticipantFactory
             }
 
             //ops.addArguments("vmodule=\"*media/*=3,*turn*=3\"");
-            ops.addArguments("enable-logging");
-            ops.addArguments("vmodule=*=3");
+            //ops.addArguments("enable-logging");
+            //ops.addArguments("vmodule=*=3");
 
             if (isRemote)
             {


### PR DESCRIPTION
Since Chrome 102 we see strange random crashes when running chrome. Reporting to chromium and it seems it is triggered inside `if (VLOG_IS_ON(3))` block. At the moment those logs are being cleared once session is over or chrome crashes, so disabling them for now. Thanks to @JonathanLennox for digging into it.