### PR TITLE
Add flag to use Chrome "Black Frame Decoder", skipping video decode complexity.

### DIFF
--- a/scripts/malleus.sh
+++ b/scripts/malleus.sh
@@ -5,7 +5,7 @@ if [ -n "$DEBUG" ]; then
 fi
 
 usage() {
-  echo "Usage: $0 [--conferences=MALLEUS_CONFERENCES] [--participants=MALLEUS_PARTICIPANTS] [--senders=MALLEUS_SENDERS] [--audio-senders=MALLEUS_AUDIO_SENDERS] [--senders-per-tab=MALLEUS_SENDERS_PER_NODE] [--receivers-per-tab=MALLEUS_RECEIVERS_PER_NODE] [--senders-per-node=MALLEUS_SENDERS_PER_NODE] [--receivers-per-node=MALLEUS_RECEIVERS_PER_NODE] [--duration=MALLEUS_DURATION (s)] [--join-delay=MALLEUS_JOIN_DELAY (ms)] [--room-name-prefix=MALLEUS_ROOM_NAME_PREFIX] [--hub-url=MALLEUS_HUB_URL] [--instance-url=MALLEUS_INSTANCE_URL] [--regions=MALLEUS_REGIONS] [--use-node-types] [--use-load-test] [--max-disrupted-bridges-pct=MALLEUS_MAX_DISRUPTED_BRIDGES_PCT] [--extra-sender-params=EXTRA_SENDER_PARAMS] [--extra-receiver-params=EXTRA_RECEIVER_PARAMS] [--debug] [--switch-speakers] [--use-stage-view] [--headless]" >&2
+  echo "Usage: $0 [--conferences=MALLEUS_CONFERENCES] [--participants=MALLEUS_PARTICIPANTS] [--senders=MALLEUS_SENDERS] [--audio-senders=MALLEUS_AUDIO_SENDERS] [--senders-per-tab=MALLEUS_SENDERS_PER_NODE] [--receivers-per-tab=MALLEUS_RECEIVERS_PER_NODE] [--senders-per-node=MALLEUS_SENDERS_PER_NODE] [--receivers-per-node=MALLEUS_RECEIVERS_PER_NODE] [--duration=MALLEUS_DURATION (s)] [--join-delay=MALLEUS_JOIN_DELAY (ms)] [--room-name-prefix=MALLEUS_ROOM_NAME_PREFIX] [--hub-url=MALLEUS_HUB_URL] [--instance-url=MALLEUS_INSTANCE_URL] [--regions=MALLEUS_REGIONS] [--use-node-types] [--use-load-test] [--max-disrupted-bridges-pct=MALLEUS_MAX_DISRUPTED_BRIDGES_PCT] [--extra-sender-params=EXTRA_SENDER_PARAMS] [--extra-receiver-params=EXTRA_RECEIVER_PARAMS] [--debug] [--switch-speakers] [--use-stage-view] [--headless] [--enable-decoding]" >&2
   exit 1
 }
 
@@ -86,6 +86,10 @@ set_defaults() {
       MALLEUS_USE_STAGE_VIEW=false
     fi
 
+    if [ -z "$MALLEUS_ENABLE_DECODING"; then
+      MALLEUS_ENABLE_DECODING=false
+    fi
+
     # Null is a fine default for MALLEUS_EXTRA_SENDER_PARAMS and MALLEUS_EXTRA_RECEIVER_PARAMS
 }
 
@@ -120,6 +124,7 @@ case $1 in
         --switch-speakers) if [ -n "$optvalue" ]; then MALLEUS_SWITCH_SPEAKERS=$optvalue; else MALLEUS_SWITCH_SPEAKERS=true; fi;;
         --use-stage-view) if [ -n "$optvalue" ]; then MALLEUS_USE_STAGE_VIEW=$optvalue; else MALLEUS_USE_STAGE_VIEW=true; fi;;
         --headless) if [ -n "$optvalue" ]; then MALLEUS_USE_HEADLESS=$optvalue; else MALLEUS_USE_HEADLESS=true; fi;;
+        --enable-decoding) if [ -n "$optvalue" ]; then MALLEUS_ENABLE_DECODING=$optvalue; else MALLEUS_ENABLE_DECODING=true; fi;;
         --extra-sender-params) MALLEUS_EXTRA_SENDER_PARAMS=$optvalue;;
         --extra-receiver-params) MALLEUS_EXTRA_RECEIVER_PARAMS=$optvalue;;
         --max-disrupted-bridges-pct) MALLEUS_MAX_DISRUPTED_BRIDGES_PCT=$optvalue;;
@@ -203,6 +208,7 @@ mvn \
 -Dorg.jitsi.malleus.switch_speakers=$MALLEUS_SWITCH_SPEAKERS \
 -Dorg.jitsi.malleus.use_stage_view=$MALLEUS_USE_STAGE_VIEW \
 -Dorg.jitsi.malleus.enable.headless=$MALLEUS_USE_HEADLESS \
+-Dorg.jitsi.malleus.enable_decoding=$MALLEUS_ENABLE_DECODING \
 -Dorg.jitsi.malleus.extra_sender_params=$MALLEUS_EXTRA_SENDER_PARAMS \
 -Dorg.jitsi.malleus.extra_receiver_params=$MALLEUS_EXTRA_RECEIVER_PARAMS \
 -Dremote.address=$MALLEUS_HUB_URL \

--- a/src/test/java/org/jitsi/meet/test/MalleusJitsificus.java
+++ b/src/test/java/org/jitsi/meet/test/MalleusJitsificus.java
@@ -68,6 +68,8 @@ public class MalleusJitsificus
         = "org.jitsi.malleus.use_stage_view";
     public static final String USE_HEADLESS
         = "org.jitsi.malleus.enable.headless";
+    public static final String ENABLE_DECODING
+        = "org.jitsi.malleus.enable_decoding";
     public static final String SENDERS_PER_TAB
         = "org.jitsi.malleus.senders_per_tab";
     public static final String RECEIVERS_PER_TAB
@@ -427,12 +429,14 @@ public class MalleusJitsificus
             boolean useLoadTest = Boolean.parseBoolean(System.getProperty(USE_LOAD_TEST_PNAME));
             boolean useNodeTypes = Boolean.parseBoolean(System.getProperty(USE_NODE_TYPES_PNAME));
             boolean useHeadless = Boolean.parseBoolean(System.getProperty(USE_HEADLESS));
+            boolean enableDecoding = Boolean.parseBoolean(System.getProperty(ENABLE_DECODING));
 
             WebParticipantOptions ops
                 = new WebParticipantOptions()
                 .setFakeStreamVideoFile(INPUT_VIDEO_FILE)
                 .setHeadless(useHeadless)
-                .setLoadTest(useLoadTest);
+                .setLoadTest(useLoadTest)
+                .setDisableDecoding(!enableDecoding);
 
             if (useNodeTypes)
             {

--- a/src/test/java/org/jitsi/meet/test/web/WebParticipantFactory.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipantFactory.java
@@ -254,6 +254,11 @@ public class WebParticipantFactory
                 ops.addArguments("window-size=1200x600");
             }
 
+            if (options.getDisableDecoding())
+            {
+                ops.addArguments("force-fieldtrials=WebRTC-BlackFrameDecoder/Enabled/");
+            }
+
             // starting version 46 we see crashes of chrome GPU process when
             // running in headless mode
             // which leaves the browser opened and selenium hang forever.

--- a/src/test/java/org/jitsi/meet/test/web/WebParticipantOptions.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipantOptions.java
@@ -81,6 +81,8 @@ public class WebParticipantOptions
 
     private static final String PROP_REMOTE = "isRemote";
 
+    private static final String PROP_DISABLE_DECODING = "disableDecoding";
+
     /**
      * The property to evaluate for parent path of the resources used when
      * loading chrome remotely like audio/video files.
@@ -334,6 +336,15 @@ public class WebParticipantOptions
     }
 
     /**
+     * Sets whether to disable decoding in the browser
+     */
+    public WebParticipantOptions setDisableDecoding(boolean value)
+    {
+        setProperty(PROP_DISABLE_DECODING, Boolean.toString(value));
+        return this;
+    }
+
+    /**
      * Sets the name of y4m video file which will be streamed through fake video
      * device by participants. The file location is relative to working folder.
      * For remote drivers a parent folder can be set and the file will be
@@ -424,6 +435,14 @@ public class WebParticipantOptions
     public boolean getLoadTest()
     {
         return Boolean.parseBoolean(getProperty(PROP_LOADTEST));
+    }
+
+    /**
+     * Whether to disable video decoding in the browser
+     */
+    public boolean getDisableDecoding()
+    {
+        return Boolean.parseBoolean(getProperty(PROP_DISABLE_DECODING));
     }
 
     /**


### PR DESCRIPTION
Enabled for Malleus, disabled for other tests.