### PR TITLE
fix: Skip error stack trace.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
@@ -203,7 +203,7 @@ public class WebParticipant extends Participant<WebDriver>
         }
         catch(Exception e)
         {
-            e.printStackTrace();
+            // ignore
         }
 
         if (conferenceUrl.getIframeToNavigateTo() != null)


### PR DESCRIPTION
The exception is otherwise always visible in iframeAPI tests.