### PR TITLE
Add "en" to accepted_languages

### DIFF
--- a/src/test/java/org/jitsi/meet/test/web/WebParticipantFactory.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipantFactory.java
@@ -245,7 +245,7 @@ public class WebParticipantFactory
 
             // Force chrome to use English instead of system language.
             Map<String, Object> prefs = new HashMap<String, Object>();
-            prefs.put("intl.accept_languages", "en-US");
+            prefs.put("intl.accept_languages", "en,en-US");
             ops.setExperimentalOption("prefs", prefs);
 
             ops.addArguments("allow-insecure-localhost");


### PR DESCRIPTION
This fixes torture tests for installations with non-english default languages.

See discussion https://community.jitsi.org/t/jitsi-meet-torture-and-non-english-default-language