### PR TITLE
fix: Fixes flaky lock room test.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/LockRoomTest.java
+++ b/src/test/java/org/jitsi/meet/test/LockRoomTest.java
@@ -212,6 +212,8 @@ public class LockRoomTest
 
         submitPassword(driver2, ROOM_KEY + "1234");
 
+        TestUtils.waitMillis(500);
+
         // wait for password prompt
         waitForPasswordDialog(driver2);
 
@@ -245,6 +247,8 @@ public class LockRoomTest
 
         passwordInput.clear();
         passwordInput.sendKeys(password);
+
+        TestUtils.waitMillis(500);
 
         ModalDialogHelper.clickOKButton(driver);
     }


### PR DESCRIPTION
After updating dialog UI we see random failures. One is where we send wrong pass and do not join the call. The other one is: Unable to locate element: {"method":"css selector","selector":"#modal\-dialog\-ok\-button"}