### PR TITLE
feat: Adds debug print in ParticipantsPane.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/AudioVideoModerationTest.java
+++ b/src/test/java/org/jitsi/meet/test/AudioVideoModerationTest.java
@@ -255,6 +255,11 @@ public class AudioVideoModerationTest
 
         participant1.getNotifications().dismissAnyJoinNotification();
 
+        // wait for the participant pane to fully open
+        // we are seeing MoveTargetOutOfBoundsException for some hidden elements
+        // when trying to hover over them
+        TestUtils.waitMillis(500);
+
         participantsPane.askToUnmute(participant2, true);
 
         TestUtils.waitForCondition(driver2, 5, (ExpectedCondition<Boolean>) d ->

--- a/src/test/java/org/jitsi/meet/test/pageobjects/web/ParticipantsPane.java
+++ b/src/test/java/org/jitsi/meet/test/pageobjects/web/ParticipantsPane.java
@@ -249,6 +249,9 @@ public class ParticipantsPane
             participant.getDriver(),
             By.cssSelector(moreButtonSelector),
             2);
+        // a debug for an error MoveTargetOutOfBoundsException: move target out of bounds
+        TestUtils.print("More options element for " + remoteParticipantEndpointId
+            + "is at:" + meetingParticipantMoreOptions.getLocation());
         Actions clickContextMenu = new Actions(participant.getDriver());
         clickContextMenu.moveToElement(meetingParticipantMoreOptions);
         clickContextMenu.perform();


### PR DESCRIPTION
Adds a wait after opening the participants pane so all elements even the hidden ones are in place before trying to mouse the mouse over them.