### PR TITLE
fix: Fixes NPE on failure to join a conference.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/base/Participant.java
+++ b/src/test/java/org/jitsi/meet/test/base/Participant.java
@@ -491,7 +491,7 @@ public abstract class Participant<T extends WebDriver>
     {
         try
         {
-            if (getMeetUrl().getIframeToNavigateTo() != null)
+            if (getMeetUrl() != null && getMeetUrl().getIframeToNavigateTo() != null)
             {
                 // let's wait for switch to that iframe, so we can save the correct page
                 WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(60));


### PR DESCRIPTION
org.openqa.selenium.JavascriptException: javascript error: APP is not defined
  (Session info: headless chrome=119.0.6045.123)
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03' System info: host: '462c96113664', ip: '172.17.0.12', os.name: 'Linux', os.arch: 'amd64', os.version: '5.15.0-1030-oracle', java.version: '11.0.19' Driver info: org.openqa.selenium.remote.RemoteWebDriver Capabilities {acceptInsecureCerts: true, browserName: chrome, browserVersion: 119.0.6045.123, chrome: {chromedriverVersion: 119.0.6045.105 (38c72552c5e..., userDataDir: /tmp/.org.chromium.Chromium...}, fedcm:accounts: true, goog:chromeOptions: {debuggerAddress: localhost:30787}, javascriptEnabled: true, networkConnectionEnabled: false, pageLoadStrategy: normal, platform: LINUX, platformName: LINUX, proxy: Proxy(), setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify, webauthn:extension:credBlob: true, webauthn:extension:largeBlob: true, webauthn:extension:minPinLength: true, webauthn:extension:prf: true, webauthn:virtualAuthenticators: true, webdriver.remote.sessionid: b78ae0edccd40fcc6f1d41804a3...} Session ID: b78ae0edccd40fcc6f1d41804a3cad25
	at jdk.internal.reflect.GeneratedConstructorAccessor26.newInstance(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(Unknown Source)
	at java.base/java.lang.reflect.Constructor.newInstance(Unknown Source)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.createException(W3CHttpResponseCodec.java:187)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:122)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:49)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:158)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
	at org.openqa.selenium.remote.RemoteWebDriver.executeScript(RemoteWebDriver.java:489)
	at org.jitsi.meet.test.web.WebParticipant.executeScript(WebParticipant.java:300)
	at org.jitsi.meet.test.web.WebParticipant.doJoinConference(WebParticipant.java:224)
	at org.jitsi.meet.test.base.Participant.joinConference(Participant.java:149)
	at org.jitsi.meet.test.web.WebTestBase.joinParticipant(WebTestBase.java:324)
	at org.jitsi.meet.test.web.WebTestBase.joinParticipantAndWait(WebTestBase.java:422)
	at org.jitsi.meet.test.web.WebTestBase.ensureOneParticipant(WebTestBase.java:82)
	at org.jitsi.meet.test.web.WebTestBase.ensureTwoParticipantsInternal(WebTestBase.java:151)
	at org.jitsi.meet.test.web.WebTestBase.ensureTwoParticipants(WebTestBase.java:126)
	at org.jitsi.meet.test.web.WebTestBase.ensureTwoParticipants(WebTestBase.java:91)
	at org.jitsi.meet.test.UDPTest.setupClass(UDPTest.java:38)
	at org.jitsi.meet.test.base.AbstractBaseTest.setupClassPrivate(AbstractBaseTest.java:195)
	at jdk.internal.reflect.GeneratedMethodAccessor3.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:139)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethodConsideringTimeout(MethodInvocationHelper.java:69)
	at org.testng.internal.invokers.ConfigInvoker.invokeConfigurationMethod(ConfigInvoker.java:361)
	at org.testng.internal.invokers.ConfigInvoker.invokeConfigurations(ConfigInvoker.java:296)
	at org.testng.internal.invokers.TestMethodWorker.invokeBeforeClassMethods(TestMethodWorker.java:180)
	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:122)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at org.testng.TestRunner.privateRun(TestRunner.java:829)
	at org.testng.TestRunner.run(TestRunner.java:602)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:437)
	at org.testng.SuiteRunner$SuiteWorker.run(SuiteRunner.java:475)
	at org.testng.internal.thread.ThreadUtil.lambda$execute$0(ThreadUtil.java:58)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
Nov 09, 2023 10:43:00 AM org.jitsi.meet.test.base.Participant saveHtmlSource SEVERE: Failed to saveHtmlSource to:org.jitsi.meet.test.UDPTest-web.participant1.html java.lang.NullPointerException
	at org.jitsi.meet.test.base.Participant.saveHtmlSource(Participant.java:493)
	at org.jitsi.meet.test.base.FailureListener.lambda$saveHtmlSources$1(FailureListener.java:274)
	at java.base/java.lang.Iterable.forEach(Unknown Source)
	at org.jitsi.meet.test.base.FailureListener.saveHtmlSources(FailureListener.java:273)
	at org.jitsi.meet.test.base.FailureListener.onTestFailure(FailureListener.java:199)
	at org.jitsi.meet.test.base.FailureListener.onConfigurationFailure(FailureListener.java:230)
	at org.testng.internal.TestListenerHelper.runPostConfigurationListeners(TestListenerHelper.java:50)
	at org.testng.internal.invokers.ConfigInvoker.runConfigurationListeners(ConfigInvoker.java:408)
	at org.testng.internal.invokers.ConfigInvoker.handleConfigurationFailure(ConfigInvoker.java:455)
	at org.testng.internal.invokers.ConfigInvoker.invokeConfigurations(ConfigInvoker.java:307)
	at org.testng.internal.invokers.TestMethodWorker.invokeBeforeClassMethods(TestMethodWorker.java:180)
	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:122)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at org.testng.TestRunner.privateRun(TestRunner.java:829)
	at org.testng.TestRunner.run(TestRunner.java:602)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:437)
	at org.testng.SuiteRunner$SuiteWorker.run(SuiteRunner.java:475)
	at org.testng.internal.thread.ThreadUtil.lambda$execute$0(ThreadUtil.java:58)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)