### PR TITLE
fix(StartMutedTest): Modify startWithAudioVideoMutedCanUnmute.

### DIFF
--- a/src/test/java/org/jitsi/meet/test/StartMutedTest.java
+++ b/src/test/java/org/jitsi/meet/test/StartMutedTest.java
@@ -274,30 +274,24 @@ public class StartMutedTest
                 "config.startWithAudioMuted=true&" +
                 "config.startWithVideoMuted=true&" +
                 "config.p2p.enabled=true");
+        JitsiMeetUrl meetUrl2 = getJitsiMeetUrl().appendConfig(
+                "config.p2p.enabled=true");
 
         // Do not use ensureTwoParticipants() because it checks for send/rec
         // bitrate which should be 0 if both participants start audio muted.
         ensureOneParticipant(meetUrl);
 
         WebParticipant participant1 = getParticipant1();
-        WebParticipant participant2 = joinSecondParticipant(meetUrl);
+        WebParticipant participant2 = joinSecondParticipant(meetUrl2);
 
         participant2.waitToJoinMUC();
         participant2.waitForIceConnected();
-
-        MeetUIUtils.waitForAudioMuted(
-            participant1.getDriver(),
-            participant2.getDriver(),
-            "participant2",
-            true);
 
         MeetUIUtils.waitForAudioMuted(
             participant2.getDriver(),
             participant1.getDriver(),
             "participant1",
             true);
-
-        participant1.getParticipantsPane().assertIsParticipantVideoMuted(participant2, true);
 
         participant2.getParticipantsPane().assertIsParticipantVideoMuted(participant1, true);
 
@@ -311,19 +305,6 @@ public class StartMutedTest
 
         MeetUIUtils.unmuteVideoAndCheck(participant1, participant2);
         participant2.getLargeVideo().assertVideoPlaying();
-
-        TestUtils.waitMillis(1000);
-
-        // Unmute p2's audio and video and check on p1.
-        MeetUIUtils.unmuteVideoAndCheck(participant2, participant1);
-        participant1.getLargeVideo().assertVideoPlaying();
-
-        participant2.getToolbar().clickAudioUnmuteButton();
-        MeetUIUtils.waitForAudioMuted(
-            participant1.getDriver(),
-            participant2.getDriver(),
-            "participant2",
-            false);
     }
 
     @Test(dependsOnMethods = { "startWithAudioVideoMutedCanUnmute" })


### PR DESCRIPTION
Only add the first participant as audio and video muted. When p1 and p2 join muted, p1 and p2 unute their audio and video sequentially, the media from p1 reaches before signaling for p1 sources reaches p2. The browser creates a receiver when it receives a packet on certain mid/ssrc. So when the client tries to set the remote description after signaling is received, this results in a collision causing the setRemoteDescription call to fail with the error: Error: Failed to execute 'setRemoteDescription' on 'RTCPeerConnection': Failed to set remote offer sdp: Failed to add remote stream ssrc: 1981416894 to {mid: 1, media_type: video}