### PR TITLE
fix(getAccessibilityCSSSelector): Finding the matching aria-label

### DIFF
--- a/src/test/java/org/jitsi/meet/test/util/MeetUIUtils.java
+++ b/src/test/java/org/jitsi/meet/test/util/MeetUIUtils.java
@@ -643,7 +643,7 @@ public class MeetUIUtils
      */
     public static String getAccessibilityCSSSelector(String accessibilityLabel)
     {
-        return String.format("[aria-label=\"%s\"]", accessibilityLabel);
+        return String.format("[aria-label^=\"%s\"]", accessibilityLabel);
     }
 
     /**


### PR DESCRIPTION
This PR is related with jitsi/jitsi-meet#14997
It fixes the test to check the related PR correctly.

`Aria-label` is not static for the participant button after the update. So, looking for the whole match doesn't work. This PR allows to find the matching tag by checking the match at the beginning.