### PR TITLE
fix: Make the toolbar visible by using the new config parameter

### DIFF
--- a/src/test/java/org/jitsi/meet/test/OneOnOneTest.java
+++ b/src/test/java/org/jitsi/meet/test/OneOnOneTest.java
@@ -44,8 +44,8 @@ public class OneOnOneTest
      */
     private static final String ONE_ON_ONE_CONFIG_OVERRIDES
         = "config.disable1On1Mode=false"
-        + "&interfaceConfig.TOOLBAR_TIMEOUT=500"
-        + "&config.alwaysVisibleToolbar=false";
+        + "&config.toolbarConfig.timeout=500"
+        + "&config.toolbarConfig.alwaysVisible=false";
 
     /**
      * Tests remote videos in filmstrip do not display in a 1-on-1 call.

--- a/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
+++ b/src/test/java/org/jitsi/meet/test/web/WebParticipant.java
@@ -49,7 +49,7 @@ public class WebParticipant extends Participant<WebDriver>
             + "&config.disableNS=true"
             + "&config.enableTalkWhileMuted=false"
             + "&config.callStatsID=false"
-            + "&config.alwaysVisibleToolbar=true"
+            + "&config.toolbarConfig.alwaysVisible=true"
             + "&config.p2p.enabled=false"
             + "&config.p2p.useStunTurn=false"
             + "&config.pcStatsInterval=1500"


### PR DESCRIPTION
This PR is related with https://github.com/jitsi/jitsi-meet/pull/15054
It fixes the test tool to check the related PR correctly.

There is a new config parameter (`config.toolbarConfig.alwaysVisible`) to make the toolbar always visible during tests. The old one doesn't work anymore. So, the test tool cannot find some buttons in some conditions if the old one is used.